### PR TITLE
fix: add SSL certificates to PyInstaller build

### DIFF
--- a/server/main.spec
+++ b/server/main.spec
@@ -1,12 +1,13 @@
 # -*- mode: python ; coding: utf-8 -*-
-
+import certifi
+import os
 
 a = Analysis(
     ['main.py'],
     pathex=[],
     binaries=[],
-    datas=[],
-    hiddenimports=[],
+    datas=[(certifi.where(), 'certifi')],
+    hiddenimports=['certifi'],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,3 +14,4 @@ Pillow
 nanoid
 python-multipart
 aiofiles
+certifi


### PR DESCRIPTION
This PR addresses the SSL certificate issue in the production build by adding the necessary SSL certificates to the PyInstaller build process. The changes ensure that the application can securely connect to external services without requiring manual installation of the certifi package.
**Changes Made:**
Updated requirements.txt to include certifi.
Modified main.spec to bundle SSL certificates with the PyInstaller build.
**Testing:**
I have not yet done any testing.