### PR TITLE
fix: 统一 i18n 使用规范，添加 vscode i18n-ally settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,12 @@
   "prettier.printWidth": 80,
   "prettier.tabWidth": 2,
   "prettier.semi": false,
-  "python.analysis.autoImportCompletions": true
+  "python.analysis.autoImportCompletions": true,
+  "i18n-ally.localesPaths": ["react/src/i18n/locales"],
+  "i18n-ally.enabledFrameworks": ["react-i18next"],
+  "i18n-ally.keystyle": "nested",
+  "i18n-ally.namespace": true,
+  "i18n-ally.pathMatcher": "{locale}/{namespaces}.json",
+  "i18n-ally.displayLanguage": "zh-CN",
+  "i18n-ally.sourceLanguage": "en"
 }

--- a/react/src/components/canvas/Canvas.tsx
+++ b/react/src/components/canvas/Canvas.tsx
@@ -131,7 +131,7 @@ function AutoSaveWrapper() {
   );
 }
 function SnapshotToolbar() {
-  const { t } = useTranslation('canvas')
+  const { t } = useTranslation()
   const editor = useEditor();
 
   useEffect(() => {
@@ -194,7 +194,7 @@ function SnapshotToolbar() {
           opacity: showCheckMark ? 1 : 0,
         }}
       >
-        {t('saved')}
+        {t('canvas.saved')}
       </span>
       <button
         onClick={() => {
@@ -202,15 +202,15 @@ function SnapshotToolbar() {
           setShowCheckMark(true);
         }}
       >
-        {t('saveSnapshot')}
+        {t('canvas.saveSnapshot')}
       </button>
-      <button onClick={load}>{t('loadSnapshot')}</button>
+      <button onClick={load}>{t('canvas.loadSnapshot')}</button>
     </div>
   );
 }
 function CustomPageMenu() {
-  const { t } = useTranslation('canvas')
-  const [pageName, setPageName] = useState(t('untitled'));
+  const { t } = useTranslation()
+  const [pageName, setPageName] = useState(t('canvas.untitled'));
   const [openWorkspace, setOpenWorkspace] = useState(false);
   const [curFile, setCurFile] = useState("");
   const editor = useEditor();
@@ -243,7 +243,7 @@ function CustomPageMenu() {
               }
             })
             .catch((err) => {
-              toast.error(t('messages.failedToCreateFile'));
+              toast.error(t('canvas.messages.failedToCreateFile'));
             });
         }}
       >
@@ -261,7 +261,7 @@ function CustomPageMenu() {
       </Button>
       <input
         type="text"
-        placeholder={t('untitled')}
+        placeholder={t('canvas.untitled')}
         className="border-none outline-none"
         value={pageName}
         onChange={(e) => setPageName(e.target.value)}

--- a/react/src/components/canvas/CanvasHeader.tsx
+++ b/react/src/components/canvas/CanvasHeader.tsx
@@ -21,7 +21,7 @@ const CanvasHeader: React.FC<CanvasHeaderProps> = ({
   onNameChange,
   onNameSave,
 }) => {
-  const { t } = useTranslation('canvas')
+  const { t } = useTranslation()
   const [isLogoHovered, setIsLogoHovered] = useState(false)
 
   const navigate = useNavigate()
@@ -55,7 +55,7 @@ const CanvasHeader: React.FC<CanvasHeaderProps> = ({
             Jaaz
           </motion.span>
           <motion.span className="flex items-center" layout aria-hidden>
-            {t('back')}
+            {t('canvas.back')}
           </motion.span>
         </motion.div>
       </motion.div>

--- a/react/src/components/chat/ChatTextarea.tsx
+++ b/react/src/components/chat/ChatTextarea.tsx
@@ -35,7 +35,7 @@ const ChatTextarea: React.FC<ChatTextareaProps> = ({
   onChange,
   onSendMessages,
 }) => {
-  const { t } = useTranslation('chat')
+  const { t } = useTranslation()
   const { configsStore } = useConfigs()
   const { textModel, imageModel, imageModels, setShowInstallDialog } =
     configsStore.getState()
@@ -68,7 +68,7 @@ const ChatTextarea: React.FC<ChatTextareaProps> = ({
   const handleSendPrompt = useCallback(() => {
     if (pending) return
     if (!textModel) {
-      toast.error(t('textarea.selectModel'))
+      toast.error(t('chat.textarea.selectModel'))
       return
     }
     // Check if there are image models, if not, prompt to install ComfyUI
@@ -77,7 +77,7 @@ const ChatTextarea: React.FC<ChatTextareaProps> = ({
       return
     }
     if (value.length === 0 || value.trim() === '') {
-      toast.error(t('textarea.enterPrompt'))
+      toast.error(t('chat.textarea.enterPrompt'))
       return
     }
 
@@ -164,7 +164,7 @@ const ChatTextarea: React.FC<ChatTextareaProps> = ({
       <Textarea
         ref={textareaRef}
         className="w-full h-full border-none outline-none resize-none"
-        placeholder={t('textarea.placeholder')}
+        placeholder={t('chat.textarea.placeholder')}
         value={value}
         autoSize
         onChange={(e) => onChange(e.target.value)}

--- a/react/src/components/common/LanguageSwitcher.tsx
+++ b/react/src/components/common/LanguageSwitcher.tsx
@@ -11,11 +11,11 @@ import { Languages } from 'lucide-react'
 
 const LanguageSwitcher = () => {
   const { changeLanguage, currentLanguage } = useLanguage()
-  const { t } = useTranslation('common')
+  const { t } = useTranslation()
 
   const languages = [
-    { code: 'en', name: t('languages.en') },
-    { code: 'zh-CN', name: t('languages.zh-CN') },
+    { code: 'en', name: t('common.languages.en') },
+    { code: 'zh-CN', name: t('common.languages.zh-CN') },
   ]
 
   return (

--- a/react/src/components/home/CanvasCard.tsx
+++ b/react/src/components/home/CanvasCard.tsx
@@ -20,16 +20,16 @@ const CanvasCard: React.FC<CanvasCardProps> = ({
   handleCanvasClick,
   handleDeleteCanvas,
 }) => {
-  const { t } = useTranslation('canvas')
+  const { t } = useTranslation()
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
   const handleDelete = async () => {
     try {
       await deleteCanvas(canvas.id)
       handleDeleteCanvas()
-      toast.success(t('messages.canvasDeleted'))
+      toast.success(t('canvas.messages.canvasDeleted'))
     } catch (error) {
-      toast.error(t('messages.failedToDelete'))
+      toast.error(t('canvas.messages.failedToDelete'))
     }
     setShowDeleteDialog(false)
   }

--- a/react/src/components/home/CanvasDeleteDialog.tsx
+++ b/react/src/components/home/CanvasDeleteDialog.tsx
@@ -26,7 +26,7 @@ const CanvasDeleteDialog: React.FC<CanvasDeleteDialogProps> = ({
   setShow,
   handleDeleteCanvas,
 }) => {
-  const { t } = useTranslation('canvas')
+  const { t } = useTranslation()
 
   return (
     <Dialog open={show} onOpenChange={setShow}>
@@ -41,19 +41,19 @@ const CanvasDeleteDialog: React.FC<CanvasDeleteDialogProps> = ({
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t('deleteDialog.title')}</DialogTitle>
+          <DialogTitle>{t('canvas.deleteDialog.title')}</DialogTitle>
         </DialogHeader>
 
         <DialogDescription>
-          {t('deleteDialog.description')}
+          {t('canvas.deleteDialog.description')}
         </DialogDescription>
 
         <DialogFooter>
           <Button variant="outline" onClick={() => setShow(false)}>
-            {t('deleteDialog.cancel')}
+            {t('canvas.deleteDialog.cancel')}
           </Button>
           <Button variant="destructive" onClick={() => handleDeleteCanvas()}>
-            {t('deleteDialog.delete')}
+            {t('canvas.deleteDialog.delete')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/react/src/components/home/CanvasList.tsx
+++ b/react/src/components/home/CanvasList.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, motion } from 'motion/react'
 import { useTranslation } from 'react-i18next'
 
 const CanvasList: React.FC = () => {
-  const { t } = useTranslation('home')
+  const { t } = useTranslation()
   const { data: canvases, refetch } = useQuery({
     queryKey: ['canvases'],
     queryFn: listCanvases,
@@ -26,7 +26,7 @@ const CanvasList: React.FC = () => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
         >
-          {t('allProjects')}
+          {t('home.allProjects')}
         </motion.span>
       )}
 

--- a/react/src/components/settings/AddProviderDialog.tsx
+++ b/react/src/components/settings/AddProviderDialog.tsx
@@ -24,7 +24,7 @@ export default function AddProviderDialog({
   onOpenChange,
   onSave
 }: AddProviderDialogProps) {
-  const { t } = useTranslation('settings')
+  const { t } = useTranslation()
   const [providerName, setProviderName] = useState('')
   const [apiUrl, setApiUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
@@ -68,16 +68,16 @@ export default function AddProviderDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
-          <DialogTitle>{t('provider.addProvider')}</DialogTitle>
+          <DialogTitle>{t('settings.provider.addProvider')}</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4 py-4">
           {/* Provider Name */}
           <div className="space-y-2">
-            <Label htmlFor="provider-name">{t('provider.providerName')}</Label>
+            <Label htmlFor="provider-name">{t('settings.provider.providerName')}</Label>
             <Input
               id="provider-name"
-              placeholder={t('provider.providerNamePlaceholder')}
+              placeholder={t('settings.provider.providerNamePlaceholder')}
               value={providerName}
               onChange={(e) => setProviderName(e.target.value)}
             />
@@ -85,10 +85,10 @@ export default function AddProviderDialog({
 
           {/* API URL */}
           <div className="space-y-2">
-            <Label htmlFor="api-url">{t('provider.apiUrl')}</Label>
+            <Label htmlFor="api-url">{t('settings.provider.apiUrl')}</Label>
             <Input
               id="api-url"
-              placeholder={t('provider.apiUrlPlaceholder')}
+              placeholder={t('settings.provider.apiUrlPlaceholder')}
               value={apiUrl}
               onChange={(e) => setApiUrl(e.target.value)}
             />
@@ -96,11 +96,11 @@ export default function AddProviderDialog({
 
           {/* API Key */}
           <div className="space-y-2">
-            <Label htmlFor="api-key">{t('provider.apiKey')}</Label>
+            <Label htmlFor="api-key">{t('settings.provider.apiKey')}</Label>
             <Input
               id="api-key"
               type="password"
-              placeholder={t('provider.apiKeyPlaceholder')}
+              placeholder={t('settings.provider.apiKeyPlaceholder')}
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
             />
@@ -110,19 +110,19 @@ export default function AddProviderDialog({
           <AddModelsList
             models={models}
             onChange={setModels}
-            label={t('models.title')}
+            label={t('settings.models.title')}
           />
         </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={handleCancel}>
-            {t('provider.cancel')}
+            {t('settings.provider.cancel')}
           </Button>
           <Button
             onClick={handleSave}
             disabled={!providerName.trim() || !apiUrl.trim()}
           >
-            {t('provider.save')}
+            {t('settings.provider.save')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/react/src/components/settings/ComfyuiSetting.tsx
+++ b/react/src/components/settings/ComfyuiSetting.tsx
@@ -14,7 +14,7 @@ interface ComfyuiSettingProps {
 }
 
 export default function ComfyuiSetting({ config, onConfigChange }: ComfyuiSettingProps) {
-  const { t } = useTranslation('settings')
+  const { t } = useTranslation()
   const [showInstallDialog, setShowInstallDialog] = useState(false)
   const [comfyUIStatus, setComfyUIStatus] = useState<'unknown' | 'installed' | 'not-installed' | 'running'>('unknown')
   const [comfyUIEnabled, setComfyUIEnabled] = useState(false)
@@ -257,17 +257,17 @@ export default function ComfyuiSetting({ config, onConfigChange }: ComfyuiSettin
   }
 
   const getComfyUIStatusText = () => {
-    if (!comfyUIEnabled) return t('comfyui.status.disabled')
+    if (!comfyUIEnabled) return t('settings.comfyui.status.disabled')
 
     switch (comfyUIStatus) {
       case 'running':
-        return t('comfyui.status.running')
+        return t('settings.comfyui.status.running')
       case 'installed':
-        return t('comfyui.status.installed')
+        return t('settings.comfyui.status.installed')
       case 'not-installed':
-        return t('comfyui.status.notInstalled')
+        return t('settings.comfyui.status.notInstalled')
       default:
-        return t('comfyui.status.checking')
+        return t('settings.comfyui.status.checking')
     }
   }
 
@@ -284,7 +284,7 @@ export default function ComfyuiSetting({ config, onConfigChange }: ComfyuiSettin
           {provider.name}
         </p>
         <div className="flex items-center gap-2">
-          <span>{t('comfyui.localImageGeneration')}</span>
+          <span>{t('settings.comfyui.localImageGeneration')}</span>
           {getComfyUIStatusIcon()}
           <span className="text-sm text-muted-foreground">
             {getComfyUIStatusText()}
@@ -300,7 +300,7 @@ export default function ComfyuiSetting({ config, onConfigChange }: ComfyuiSettin
           onCheckedChange={handleComfyUIToggle}
         />
         <Label htmlFor="comfyui-enable" className="text-sm font-medium">
-          {t('comfyui.enable')}
+          {t('settings.comfyui.enable')}
         </Label>
         {/* Debug button for verification */}
         <Button
@@ -309,7 +309,7 @@ export default function ComfyuiSetting({ config, onConfigChange }: ComfyuiSettin
           size="sm"
           className="ml-4"
         >
-          {t('comfyui.debugStatus')}
+          {t('settings.comfyui.debugStatus')}
         </Button>
       </div>
 
@@ -318,9 +318,9 @@ export default function ComfyuiSetting({ config, onConfigChange }: ComfyuiSettin
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4">
           <div className="flex items-center justify-between">
             <div>
-              <h4 className="font-medium text-yellow-800">{t('comfyui.notInstalledTitle')}</h4>
+              <h4 className="font-medium text-yellow-800">{t('settings.comfyui.notInstalledTitle')}</h4>
               <p className="text-sm text-yellow-700 mt-1">
-                {t('comfyui.notInstalledDescription')}
+                {t('settings.comfyui.notInstalledDescription')}
               </p>
             </div>
             <Button
@@ -330,7 +330,7 @@ export default function ComfyuiSetting({ config, onConfigChange }: ComfyuiSettin
               className="border-yellow-300 text-yellow-700 hover:bg-yellow-100"
             >
               <Download className="w-4 h-4 mr-2" />
-              {t('comfyui.installButton')}
+              {t('settings.comfyui.installButton')}
             </Button>
           </div>
         </div>

--- a/react/src/components/settings/CommonSetting.tsx
+++ b/react/src/components/settings/CommonSetting.tsx
@@ -20,7 +20,7 @@ export default function CommonSetting({
   onConfigChange,
   onDeleteProvider,
 }: CommonSettingProps) {
-  const { t } = useTranslation('settings')
+  const { t } = useTranslation()
   const provider = PROVIDER_NAME_MAPPING[providerKey] || {
     name:
       providerKey.charAt(0).toUpperCase() +
@@ -81,7 +81,7 @@ export default function CommonSetting({
               className="text-red-600 hover:text-red-700 hover:bg-red-50"
             >
               <Trash2 className="h-4 w-4 mr-1" />
-              {t('provider.delete')}
+              {t('settings.provider.delete')}
             </Button>
           </div>
         )}
@@ -89,10 +89,10 @@ export default function CommonSetting({
 
       {/* API URL Input */}
       <div className="space-y-2">
-        <Label htmlFor={`${providerKey}-url`}>{t('provider.apiUrl')}</Label>
+        <Label htmlFor={`${providerKey}-url`}>{t('settings.provider.apiUrl')}</Label>
         <Input
           id={`${providerKey}-url`}
-          placeholder={t('provider.apiUrlPlaceholder')}
+          placeholder={t('settings.provider.apiUrlPlaceholder')}
           value={config.url ?? ''}
           onChange={(e) => handleChange('url', e.target.value)}
           className="w-full"
@@ -101,17 +101,17 @@ export default function CommonSetting({
 
       {/* API Key Input */}
       <div className="space-y-2">
-        <Label htmlFor={`${providerKey}-apiKey`}>{t('provider.apiKey')}</Label>
+        <Label htmlFor={`${providerKey}-apiKey`}>{t('settings.provider.apiKey')}</Label>
         <Input
           id={`${providerKey}-apiKey`}
           type="password"
-          placeholder={t('provider.apiKeyPlaceholder')}
+          placeholder={t('settings.provider.apiKeyPlaceholder')}
           value={config.api_key ?? ''}
           onChange={(e) => handleChange('api_key', e.target.value)}
           className="w-full"
         />
         <p className="text-xs text-gray-500">
-          {t('provider.apiKeyDescription')}
+          {t('settings.provider.apiKeyDescription')}
         </p>
       </div>
 
@@ -121,7 +121,7 @@ export default function CommonSetting({
           <AddModelsList
             models={config.models || {}}
             onChange={handleModelsChange}
-            label={t('models.title')}
+            label={t('settings.models.title')}
           />
         </div>
       )}
@@ -133,7 +133,7 @@ export default function CommonSetting({
           <Input
             id={`${providerKey}-maxTokens`}
             type="number"
-            placeholder={t('provider.maxTokensPlaceholder')}
+            placeholder={t('settings.provider.maxTokensPlaceholder')}
             value={config.max_tokens ?? 8192}
             onChange={(e) =>
               handleChange('max_tokens', parseInt(e.target.value))
@@ -141,7 +141,7 @@ export default function CommonSetting({
             className="w-full"
           />
           <p className="text-xs text-gray-500">
-            {t('provider.maxTokensDescription')}
+            {t('settings.provider.maxTokensDescription')}
           </p>
         </div>
       )}

--- a/react/src/i18n/README.md
+++ b/react/src/i18n/README.md
@@ -33,16 +33,11 @@ src/i18n/
 import { useTranslation } from 'react-i18next'
 
 function MyComponent() {
-  // 使用特定命名空间
-  const { t } = useTranslation('home')
-
-  // 使用多个命名空间
-  const { t: tCommon } = useTranslation('common')
+  const { t } = useTranslation()
 
   return (
     <div>
       <h1>{t('title')}</h1>
-      <button>{tCommon('buttons.save')}</button>
     </div>
   )
 }
@@ -59,8 +54,8 @@ function MyComponent() {
 //   }
 // }
 
-const { t } = useTranslation('common')
-return <button>{t('buttons.save')}</button>
+const { t } = useTranslation()
+return <button>{t('common.buttons.save')}</button>
 ```
 
 ### 3. 使用插值
@@ -71,8 +66,8 @@ return <button>{t('buttons.save')}</button>
 //   "welcome": "欢迎, {{name}}!"
 // }
 
-const { t } = useTranslation('common')
-return <div>{t('welcome', { name: 'Jaaz' })}</div>
+const { t } = useTranslation()
+return <div>{t('common.welcome', { name: 'Jaaz' })}</div>
 ```
 
 ### 4. 语言切换

--- a/react/src/i18n/index.ts
+++ b/react/src/i18n/index.ts
@@ -9,11 +9,11 @@ import canvasEn from './locales/en/canvas.json'
 import chatEn from './locales/en/chat.json'
 import settingsEn from './locales/en/settings.json'
 
-import commonZh from './locales/zh-cn/common.json'
-import homeZh from './locales/zh-cn/home.json'
-import canvasZh from './locales/zh-cn/canvas.json'
-import chatZh from './locales/zh-cn/chat.json'
-import settingsZh from './locales/zh-cn/settings.json'
+import commonZh from './locales/zh-CN/common.json'
+import homeZh from './locales/zh-CN/home.json'
+import canvasZh from './locales/zh-CN/canvas.json'
+import chatZh from './locales/zh-CN/chat.json'
+import settingsZh from './locales/zh-CN/settings.json'
 
 const resources = {
   en: {

--- a/react/src/i18n/locales/zh-CN/canvas.json
+++ b/react/src/i18n/locales/zh-CN/canvas.json
@@ -1,0 +1,28 @@
+{
+  "title": "画布",
+  "rename": "重命名画布",
+  "delete": "删除画布",
+  "share": "分享画布",
+  "export": "导出画布",
+  "import": "导入画布",
+  "untitled": "无标题",
+  "back": "返回",
+  "saveSnapshot": "保存快照",
+  "loadSnapshot": "加载快照",
+  "saved": "已保存 ✅",
+  "messages": {
+    "canvasRenamed": "画布重命名成功",
+    "canvasDeleted": "画布删除成功",
+    "canvasExported": "画布导出成功",
+    "canvasImported": "画布导入成功",
+    "failedToRename": "重命名画布失败",
+    "failedToDelete": "删除画布失败",
+    "failedToCreateFile": "创建文件失败"
+  },
+  "deleteDialog": {
+    "title": "删除画布",
+    "description": "确定要删除此画布吗？此操作无法撤销。",
+    "cancel": "取消",
+    "delete": "删除"
+  }
+}

--- a/react/src/i18n/locales/zh-CN/chat.json
+++ b/react/src/i18n/locales/zh-CN/chat.json
@@ -1,0 +1,9 @@
+{
+  "newChat": "新建聊天",
+  "placeholder": "在这里输入你的消息...",
+  "textarea": {
+    "placeholder": "输入您的设计需求",
+    "selectModel": "请选择一个文本模型！如果您还没有设置 API 密钥，请前往设置页面进行配置。",
+    "enterPrompt": "请输入提示内容"
+  }
+}

--- a/react/src/i18n/locales/zh-CN/common.json
+++ b/react/src/i18n/locales/zh-CN/common.json
@@ -1,0 +1,46 @@
+{
+  "languages": {
+    "en": "English",
+    "zh-CN": "简体中文"
+  },
+  "buttons": {
+    "save": "保存",
+    "cancel": "取消",
+    "delete": "删除",
+    "edit": "编辑",
+    "create": "创建",
+    "submit": "提交",
+    "loading": "加载中...",
+    "retry": "重试"
+  },
+  "common": {
+    "yes": "是",
+    "no": "否",
+    "ok": "确定",
+    "error": "错误",
+    "success": "成功",
+    "warning": "警告",
+    "info": "信息"
+  },
+  "messages": {
+    "success": "操作成功完成",
+    "error": "发生了错误",
+    "loading": "正在加载，请稍候...",
+    "noData": "暂无数据",
+    "confirmDelete": "确定要删除此项吗？",
+    "saved": "保存成功",
+    "deleted": "删除成功"
+  },
+  "navigation": {
+    "home": "首页",
+    "canvas": "画布",
+    "settings": "设置",
+    "back": "返回"
+  },
+  "dialog": {
+    "confirmTitle": "确认操作",
+    "confirmDescription": "此操作无法撤销",
+    "cancel": "取消",
+    "confirm": "确认"
+  }
+}

--- a/react/src/i18n/locales/zh-CN/home.json
+++ b/react/src/i18n/locales/zh-CN/home.json
@@ -1,0 +1,7 @@
+{
+  "title": "你好，Jaaz！",
+  "subtitle": "准备好将你的想法变成艺术吗？",
+  "allProjects": "所有项目",
+  "noCanvases": "还没有画布",
+  "newCanvas": "新建画布"
+}

--- a/react/src/i18n/locales/zh-CN/settings.json
+++ b/react/src/i18n/locales/zh-CN/settings.json
@@ -1,0 +1,54 @@
+{
+  "title": "设置",
+  "messages": {
+    "settingsSaved": "设置保存成功",
+    "settingsReset": "设置已重置为默认值",
+    "failedToSave": "保存设置失败",
+    "failedToLoad": "加载配置失败"
+  },
+  "models": {
+    "title": "模型",
+    "placeholder": "输入模型名称",
+    "addModel": "添加模型",
+    "types": {
+      "text": "语言模型",
+      "image": "生图模型",
+      "video": "视频生成模型"
+    }
+  },
+  "provider": {
+    "addProvider": "添加提供商",
+    "providerName": "提供商名称",
+    "providerNamePlaceholder": "输入提供商名称",
+    "apiUrl": "API 地址",
+    "apiUrlPlaceholder": "输入 API 地址",
+    "apiKey": "API 密钥",
+    "apiKeyPlaceholder": "输入 API 密钥",
+    "apiKeyDescription": "您的 API 密钥将被安全存储",
+    "maxTokens": "最大令牌数",
+    "maxTokensPlaceholder": "输入最大令牌数",
+    "maxTokensDescription": "响应中的最大令牌数",
+    "customProvider": "✨ 自定义提供商",
+    "imageGeneration": "🎨 图像生成",
+    "delete": "删除",
+    "save": "保存",
+    "cancel": "取消"
+  },
+  "comfyui": {
+    "title": "ComfyUI",
+    "localImageGeneration": "🎨 本地图像生成",
+    "enable": "启用 ComfyUI 本地图像生成",
+    "debugStatus": "🔍 调试状态",
+    "status": {
+      "disabled": "已禁用",
+      "running": "运行中",
+      "installed": "已安装（未运行）",
+      "notInstalled": "未安装",
+      "checking": "检查中..."
+    },
+    "notInstalledTitle": "ComfyUI 未安装",
+    "notInstalledDescription": "安装 ComfyUI 以启用 Flux 模型的本地图像生成",
+    "installButton": "安装 ComfyUI"
+  },
+  "saveSettings": "保存设置"
+}

--- a/react/src/routes/canvas.$id.tsx
+++ b/react/src/routes/canvas.$id.tsx
@@ -23,7 +23,7 @@ function Canvas() {
   const [canvasName, setCanvasName] = useState('')
   const [session, setSession] = useState<Session | null>(null)
   const [sessionList, setSessionList] = useState<Session[]>([])
-  const { t } = useTranslation('chat')
+  const { t } = useTranslation()
 
   const { id } = useParams({ from: '/canvas/$id' })
   const search = useSearch({ from: '/canvas/$id' }) as { sessionId: string }
@@ -56,7 +56,7 @@ function Canvas() {
   const handleNewChat = () => {
     const newSession: Session = {
       id: nanoid(),
-      title: t('newChat'),
+      title: t('chat.newChat'),
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
       model: session?.model || 'gpt-4o',

--- a/react/src/routes/index.tsx
+++ b/react/src/routes/index.tsx
@@ -18,8 +18,7 @@ export const Route = createFileRoute('/')({
 function Home() {
   const [prompt, setPrompt] = useState('')
   const navigate = useNavigate()
-  const { t } = useTranslation('home')
-  const { t: tCommon } = useTranslation('common')
+  const { t } = useTranslation()
 
   const { mutate: createCanvasMutation, isPending } = useMutation({
     mutationFn: createCanvas,
@@ -27,7 +26,7 @@ function Home() {
       navigate({ to: '/canvas/$id', params: { id: data.id } })
     },
     onError: (error) => {
-      toast.error(tCommon('messages.error'), {
+      toast.error(t('common.messages.error'), {
         description: error.message,
       })
     },
@@ -45,7 +44,7 @@ function Home() {
             transition={{ duration: 0.5 }}
           >
             <h1 className="text-5xl font-bold mb-2 mt-8 text-center">
-              {t('title')}
+              {t('home.title')}
             </h1>
           </motion.div>
           <motion.div
@@ -54,7 +53,7 @@ function Home() {
             transition={{ duration: 0.5 }}
           >
             <p className="text-xl text-gray-500 mb-8 text-center">
-              {t('subtitle')}
+              {t('home.subtitle')}
             </p>
           </motion.div>
 
@@ -65,7 +64,7 @@ function Home() {
             messages={[]}
             onSendMessages={(messages, configs) => {
               createCanvasMutation({
-                name: t('newCanvas'),
+                name: t('home.newCanvas'),
                 canvas_id: nanoid(),
                 messages: messages,
                 session_id: nanoid(),

--- a/react/src/routes/settings.tsx
+++ b/react/src/routes/settings.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute('/settings')({
 })
 
 export default function Settings() {
-  const { t } = useTranslation('settings')
+  const { t } = useTranslation()
   const [config, setConfig] = useState<{
     [key: string]: LLMConfig
   }>(DEFAULT_CONFIG)
@@ -90,7 +90,7 @@ export default function Settings() {
         }
       } catch (error) {
         console.error('Error loading configuration:', error)
-        setErrorMessage(t('messages.failedToLoad'))
+        setErrorMessage(t('settings.messages.failedToLoad'))
       } finally {
         setIsLoading(false)
       }
@@ -145,7 +145,7 @@ export default function Settings() {
       }
     } catch (error) {
       console.error('Error saving settings:', error)
-      setErrorMessage(t('messages.failedToSave'))
+      setErrorMessage(t('settings.messages.failedToSave'))
     }
   }
 
@@ -162,7 +162,7 @@ export default function Settings() {
       <Card className="w-full max-w-[800px] shadow-lg">
         <CardHeader className="space-y-1">
           <CardTitle className="text-2xl font-bold text-center">
-            {t('title')}
+            {t('settings.title')}
           </CardTitle>
           <div className="pt-4">
             <Button
@@ -170,7 +170,7 @@ export default function Settings() {
               className="flex items-center gap-2"
             >
               <Plus className="h-4 w-4" />
-              {t('provider.addProvider')}
+              {t('settings.provider.addProvider')}
             </Button>
           </div>
         </CardHeader>
@@ -206,7 +206,7 @@ export default function Settings() {
 
           <div className="flex justify-center fixed bottom-4 left-1/2 -translate-x-1/2">
             <Button onClick={handleSave} className="w-[400px]" size={'lg'}>
-              <Save className="mr-2 h-4 w-4" /> {t('saveSettings')}
+              <Save className="mr-2 h-4 w-4" /> {t('settings.saveSettings')}
             </Button>
           </div>
 


### PR DESCRIPTION
```ts
const { t } = useTranslation() // 改为只使用这种形式
placeholder={t('settings.provider.providerNamePlaceholder')}  // 使用时 带上 settings 前缀

const {t} = useTranslation('settings') // 此前使用这样的形式，感觉不利于查找
placeholder={t('provider.providerNamePlaceholder')}
```

另外，添加了 vscode i18n-ally 插件的设置