### PR TITLE
fix: update requirements.txt to include langchain_ollama and langchain_openai

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,3 +19,5 @@ websocket-client # needed for comfyui execution
 rich # needed for comfyui execution
 typer # needed for comfyui execution
 langgraph
+langchain_ollama
+langchain_openai


### PR DESCRIPTION
目前用 `pip install -r requirements.txt` ，安装依赖后运行会报错：
 
Traceback (most recent call last):
  File "E:\3-github-project\AI\jaaz\server\main.py", line 17, in <module>
    from routers import config, agent, workspace, image_tools, canvas
  File "E:\3-github-project\AI\jaaz\server\routers\agent.py", line 26, in <module>
    from langchain_openai import ChatOpenAI
ModuleNotFoundError: No module named 'langchain_openai'