### PR TITLE
feat: 添加视频生成确认功能

### DIFF
--- a/react/src/components/chat/Message/ToolCallTag.tsx
+++ b/react/src/components/chat/Message/ToolCallTag.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button'
 import { TOOL_CALL_NAME_MAPPING } from '@/constants'
 import { cn } from '@/lib/utils'
 import { ToolCall } from '@/types/types'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { ChevronDown, ChevronRight, AlertTriangle, Check, X } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import Markdown from 'react-markdown'
 import MultiChoicePrompt from '../MultiChoicePrompt'
@@ -17,12 +17,18 @@ type ToolCallTagProps = {
   toolCall: ToolCall
   isExpanded: boolean
   onToggleExpand: () => void
+  requiresConfirmation?: boolean
+  onConfirm?: () => void
+  onCancel?: () => void
 }
 
 const ToolCallTag: React.FC<ToolCallTagProps> = ({
   toolCall,
   isExpanded,
   onToggleExpand,
+  requiresConfirmation = false,
+  onConfirm,
+  onCancel,
 }) => {
   const { name, arguments: inputs } = toolCall.function
 
@@ -38,15 +44,31 @@ const ToolCallTag: React.FC<ToolCallTagProps> = ({
   if (name.startsWith('transfer_to')) {
     return null
   }
+
+  const needsConfirmation = requiresConfirmation
+
   let parsedArgs = null
-  if (inputs.endsWith('}')) {
+  try {
+    parsedArgs = JSON.parse(inputs)
+  } catch (error) {
+    console.error('Error parsing args:', error, 'Raw input:', inputs)
+    // 尝试清理输入字符串，移除可能的额外内容
     try {
-      parsedArgs = JSON.parse(inputs)
-    } catch (error) {
-      console.error('Error parsing args:', error)
+      const cleanedInput = inputs.trim()
+      const jsonEndIndex = cleanedInput.lastIndexOf('}')
+      if (jsonEndIndex > 0) {
+        const jsonPart = cleanedInput.substring(0, jsonEndIndex + 1)
+        parsedArgs = JSON.parse(jsonPart)
+        console.log('Successfully parsed cleaned JSON:', jsonPart)
+      }
+    } catch (cleanError) {
+      console.error('Failed to parse even after cleaning:', cleanError)
     }
   }
 
+
+
+  // 普通模式的样式
   return (
     <div className="bg-green-50 dark:bg-green-950/50 border border-green-200 dark:border-green-800 rounded-md shadow-sm overflow-hidden">
       {/* Header */}
@@ -76,6 +98,18 @@ const ToolCallTag: React.FC<ToolCallTagProps> = ({
           </p>
         </div>
         <div className="flex items-center gap-2">
+          {needsConfirmation && (
+            <div className="bg-yellow-200 dark:bg-yellow-800 text-yellow-800 dark:text-yellow-200 text-xs px-2 py-0.5 rounded-full flex items-center gap-1">
+              <AlertTriangle className="h-3 w-3" />
+              需确认
+            </div>
+          )}
+          {!needsConfirmation && toolCall.result === "工具调用已取消" && (
+            <div className="bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-200 text-xs px-2 py-0.5 rounded-full flex items-center gap-1">
+              <X className="h-3 w-3" />
+              已取消
+            </div>
+          )}
           {parsedArgs && Object.keys(parsedArgs).length > 0 && (
             <div className="bg-green-200 dark:bg-green-800 text-green-800 dark:text-green-200 text-xs px-2 py-0.5 rounded-full">
               {Object.keys(parsedArgs).length}
@@ -121,6 +155,39 @@ const ToolCallTag: React.FC<ToolCallTagProps> = ({
               </div>
             )}
             {toolCall.result && <ToolCallContentV2 content={toolCall.result} />}
+
+            {/* 确认按钮 - 仅在需要确认时显示 */}
+            {needsConfirmation && (
+              <div className="mt-4 pt-4 border-t border-green-200 dark:border-green-800">
+                <div className="flex gap-2">
+                  <Button
+                    onClick={onConfirm}
+                    className="flex-1 bg-green-600 hover:bg-green-700 text-white"
+                  >
+                    <Check className="h-4 w-4 mr-2" />
+                    确认执行
+                  </Button>
+                  <Button
+                    onClick={onCancel}
+                    variant="outline"
+                    className="flex-1 border-green-300 text-green-700 hover:bg-green-100"
+                  >
+                    <X className="h-4 w-4 mr-2" />
+                    取消
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* 取消状态显示 */}
+            {!needsConfirmation && toolCall.result === "工具调用已取消" && (
+              <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-800">
+                <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
+                  <X className="h-4 w-4" />
+                  <span className="text-sm">工具调用已取消</span>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/react/src/lib/event.ts
+++ b/react/src/lib/event.ts
@@ -37,6 +37,9 @@ export type TEvents = {
   'Socket::Session::ToolCallResult': ISocket.SessionToolCallResultEvent
   'Socket::Session::AllMessages': ISocket.SessionAllMessagesEvent
   'Socket::Session::ToolCallProgress': ISocket.SessionToolCallProgressEvent
+  'Socket::Session::ToolCallPendingConfirmation': ISocket.SessionToolCallPendingConfirmationEvent
+  'Socket::Session::ToolCallConfirmed': ISocket.SessionToolCallConfirmedEvent
+  'Socket::Session::ToolCallCancelled': ISocket.SessionToolCallCancelledEvent
   // ********** Socket events - End **********
 
   // ********** Canvas events - Start **********

--- a/react/src/lib/socket.ts
+++ b/react/src/lib/socket.ts
@@ -101,6 +101,15 @@ export class SocketIOManager {
       case ISocket.SessionEventType.ToolCall:
         eventBus.emit('Socket::Session::ToolCall', data)
         break
+      case ISocket.SessionEventType.ToolCallPendingConfirmation:
+        eventBus.emit('Socket::Session::ToolCallPendingConfirmation', data)
+        break
+      case ISocket.SessionEventType.ToolCallConfirmed:
+        eventBus.emit('Socket::Session::ToolCallConfirmed', data)
+        break
+      case ISocket.SessionEventType.ToolCallCancelled:
+        eventBus.emit('Socket::Session::ToolCallCancelled', data)
+        break
       case ISocket.SessionEventType.ToolCallArguments:
         eventBus.emit('Socket::Session::ToolCallArguments', data)
         break

--- a/react/src/types/socket.ts
+++ b/react/src/types/socket.ts
@@ -14,6 +14,9 @@ export enum SessionEventType {
   ToolCallResult = 'tool_call_result',
   AllMessages = 'all_messages',
   ToolCallProgress = 'tool_call_progress',
+  ToolCallPendingConfirmation = 'tool_call_pending_confirmation',
+  ToolCallConfirmed = 'tool_call_confirmed',
+  ToolCallCancelled = 'tool_call_cancelled',
 }
 
 export interface SessionBaseEvent {
@@ -75,6 +78,24 @@ export interface SessionToolCallProgressEvent extends SessionBaseEvent {
   update: string
 }
 
+export interface SessionToolCallPendingConfirmationEvent
+  extends SessionBaseEvent {
+  type: SessionEventType.ToolCallPendingConfirmation
+  id: string
+  name: ToolCallFunctionName
+  arguments: string
+}
+
+export interface SessionToolCallConfirmedEvent extends SessionBaseEvent {
+  type: SessionEventType.ToolCallConfirmed
+  id: string
+}
+
+export interface SessionToolCallCancelledEvent extends SessionBaseEvent {
+  type: SessionEventType.ToolCallCancelled
+  id: string
+}
+
 export type SessionUpdateEvent =
   | SessionDeltaEvent
   | SessionToolCallEvent
@@ -87,3 +108,6 @@ export type SessionUpdateEvent =
   | SessionErrorEvent
   | SessionInfoEvent
   | SessionToolCallResultEvent
+  | SessionToolCallPendingConfirmationEvent
+  | SessionToolCallConfirmedEvent
+  | SessionToolCallCancelledEvent

--- a/server/main.py
+++ b/server/main.py
@@ -7,7 +7,7 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
 print('Importing websocket_router')
 from routers.websocket_router import *  # DO NOT DELETE THIS LINE, OTHERWISE, WEBSOCKET WILL NOT WORK
 print('Importing routers')
-from routers import config_router, image_router, root_router, workspace, canvas, ssl_test, chat_router, settings
+from routers import config_router, image_router, root_router, workspace, canvas, ssl_test, chat_router, settings, tool_confirmation
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi import FastAPI
@@ -55,6 +55,7 @@ app.include_router(workspace.router)
 app.include_router(image_router.router)
 app.include_router(ssl_test.router)
 app.include_router(chat_router.router)
+app.include_router(tool_confirmation.router)
 
 # Mount the React build directory
 react_build_dir = os.environ.get('UI_DIST_DIR', os.path.join(

--- a/server/routers/tool_confirmation.py
+++ b/server/routers/tool_confirmation.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Dict, Any
+from services.websocket_service import send_to_websocket
+from services.tool_confirmation_manager import tool_confirmation_manager
+
+router = APIRouter(prefix="/api")
+
+class ToolConfirmationRequest(BaseModel):
+    session_id: str
+    tool_call_id: str
+    confirmed: bool
+
+@router.post("/tool_confirmation")
+async def handle_tool_confirmation(request: ToolConfirmationRequest):
+    """处理工具调用确认"""
+    try:
+        if request.confirmed:
+            # 确认工具调用
+            success = tool_confirmation_manager.confirm_tool(
+                request.tool_call_id)
+            if success:
+                await send_to_websocket(request.session_id, {
+                    'type': 'tool_call_confirmed',
+                    'id': request.tool_call_id
+                })
+            else:
+                raise HTTPException(
+                    status_code=404, detail="Tool call not found or already processed")
+        else:
+            # 取消工具调用
+            success = tool_confirmation_manager.cancel_confirmation(
+                request.tool_call_id)
+            if success:
+                await send_to_websocket(request.session_id, {
+                    'type': 'tool_call_cancelled',
+                    'id': request.tool_call_id
+                })
+            else:
+                raise HTTPException(
+                    status_code=404, detail="Tool call not found or already processed")
+
+        return {"status": "success"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/server/services/langgraph_service/StreamProcessor.py
+++ b/server/services/langgraph_service/StreamProcessor.py
@@ -113,13 +113,31 @@ class StreamProcessor:
         self.tool_calls = [tc for tc in tool_calls if tc.get('name')]
         print('😘tool_call event', tool_calls)
 
+        # 需要确认的工具列表
+        TOOLS_REQUIRING_CONFIRMATION = {
+            'generate_video_by_kling_v2_jaaz',
+            'generate_video_by_seedance_v1_pro_volces',
+            'generate_video_by_seedance_v1_lite_volces',
+            'generate_video_by_seedance_v1_jaaz',
+            'generate_video_by_hailuo_02_jaaz',
+        }
+
         for tool_call in self.tool_calls:
-            await self.websocket_service(self.session_id, {
-                'type': 'tool_call',
-                'id': tool_call.get('id'),
-                'name': tool_call.get('name'),
-                'arguments': '{}'
-            })
+            tool_name = tool_call.get('name')
+
+            # 检查是否需要确认
+            if tool_name in TOOLS_REQUIRING_CONFIRMATION:
+                # 对于需要确认的工具，不在这里发送事件，让工具函数自己处理
+                print(
+                    f'🔄 Tool {tool_name} requires confirmation, skipping StreamProcessor event')
+                continue
+            else:
+                await self.websocket_service(self.session_id, {
+                    'type': 'tool_call',
+                    'id': tool_call.get('id'),
+                    'name': tool_name,
+                    'arguments': '{}'
+                })
 
     async def _handle_tool_call_chunks(self, tool_call_chunks: List[Any]) -> None:
         """处理工具调用参数流"""

--- a/server/services/langgraph_service/StreamProcessor.py
+++ b/server/services/langgraph_service/StreamProcessor.py
@@ -117,7 +117,8 @@ class StreamProcessor:
         TOOLS_REQUIRING_CONFIRMATION = {
             'generate_video_by_kling_v2_jaaz',
             'generate_video_by_seedance_v1_pro_volces',
-            'generate_video_by_seedance_v1_lite_volces',
+            'generate_video_by_seedance_v1_lite_i2v',
+            'generate_video_by_seedance_v1_lite_t2v',
             'generate_video_by_seedance_v1_jaaz',
             'generate_video_by_hailuo_02_jaaz',
         }

--- a/server/services/tool_confirmation_manager.py
+++ b/server/services/tool_confirmation_manager.py
@@ -1,0 +1,86 @@
+import asyncio
+from typing import Dict, Any, Optional
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+
+@dataclass
+class ToolConfirmationRequest:
+    tool_call_id: str
+    session_id: str
+    tool_name: str
+    arguments: Dict[str, Any]
+    created_at: datetime
+    confirmed: Optional[bool] = None
+
+
+class ToolConfirmationManager:
+    """工具确认管理器"""
+
+    def __init__(self):
+        self.pending_confirmations: Dict[str, ToolConfirmationRequest] = {}
+        self.confirmation_timeout = timedelta(minutes=5)  # 5分钟超时
+
+    async def request_confirmation(self, tool_call_id: str, session_id: str, tool_name: str, arguments: Dict[str, Any]) -> bool:
+        """请求工具确认，返回是否已确认"""
+        request = ToolConfirmationRequest(
+            tool_call_id=tool_call_id,
+            session_id=session_id,
+            tool_name=tool_name,
+            arguments=arguments,
+            created_at=datetime.now()
+        )
+
+        self.pending_confirmations[tool_call_id] = request
+
+        # 等待确认或超时
+        try:
+            await asyncio.wait_for(
+                self._wait_for_confirmation(tool_call_id),
+                timeout=self.confirmation_timeout.total_seconds()
+            )
+            return request.confirmed is True
+        except asyncio.TimeoutError:
+            # 超时，自动取消
+            self.cancel_confirmation(tool_call_id)
+            return False
+
+    async def _wait_for_confirmation(self, tool_call_id: str):
+        """等待确认"""
+        while tool_call_id in self.pending_confirmations:
+            request = self.pending_confirmations[tool_call_id]
+            if request.confirmed is not None:
+                return
+            await asyncio.sleep(0.1)
+
+    def confirm_tool(self, tool_call_id: str) -> bool:
+        """确认工具调用"""
+        if tool_call_id in self.pending_confirmations:
+            self.pending_confirmations[tool_call_id].confirmed = True
+            return True
+        return False
+
+    def cancel_confirmation(self, tool_call_id: str) -> bool:
+        """取消工具调用"""
+        if tool_call_id in self.pending_confirmations:
+            self.pending_confirmations[tool_call_id].confirmed = False
+            return True
+        return False
+
+    def get_pending_request(self, tool_call_id: str) -> Optional[ToolConfirmationRequest]:
+        """获取待确认的请求"""
+        return self.pending_confirmations.get(tool_call_id)
+
+    def cleanup_expired(self):
+        """清理过期的确认请求"""
+        now = datetime.now()
+        expired_ids = [
+            tool_call_id for tool_call_id, request in self.pending_confirmations.items()
+            if now - request.created_at > self.confirmation_timeout
+        ]
+        for tool_call_id in expired_ids:
+            del self.pending_confirmations[tool_call_id]
+
+
+# 全局实例
+tool_confirmation_manager = ToolConfirmationManager()

--- a/server/services/websocket_service.py
+++ b/server/services/websocket_service.py
@@ -1,8 +1,10 @@
 # services/websocket_service.py
 from services.websocket_state import sio, get_all_socket_ids
 import traceback
+from typing import Any, Dict
 
-async def broadcast_session_update(session_id: str, canvas_id: str, event: dict):
+
+async def broadcast_session_update(session_id: str, canvas_id: str | None, event: Dict[str, Any]):
     socket_ids = get_all_socket_ids()
     if socket_ids:
         try:
@@ -18,8 +20,11 @@ async def broadcast_session_update(session_id: str, canvas_id: str, event: dict)
 
 # compatible with legacy codes
 # TODO: All Broadcast should have a canvas_id
-async def send_to_websocket(session_id: str, event: dict):
+
+
+async def send_to_websocket(session_id: str, event: Dict[str, Any]):
     await broadcast_session_update(session_id, None, event)
+
 
 async def broadcast_init_done():
     try:

--- a/server/tools/generate_video_by_seedance_v1_pro_volces.py
+++ b/server/tools/generate_video_by_seedance_v1_pro_volces.py
@@ -4,6 +4,9 @@ from langchain_core.tools import tool, InjectedToolCallId  # type: ignore
 from langchain_core.runnables import RunnableConfig
 from tools.video_generation.video_generation_core import generate_video_with_provider
 from .utils.image_utils import process_input_image
+from services.tool_confirmation_manager import tool_confirmation_manager
+from services.websocket_service import send_to_websocket
+import json
 
 
 class GenerateVideoBySeedanceV1InputSchema(BaseModel):
@@ -49,6 +52,35 @@ async def generate_video_by_seedance_v1_pro_volces(
     """
     Generate a video using Seedance V1 model via configured provider
     """
+    # 检查是否需要确认
+    ctx = config.get('configurable', {})
+    session_id = ctx.get('session_id', '')
+
+    arguments = {
+        'prompt': prompt,
+        'resolution': resolution,
+        'duration': duration,
+        'aspect_ratio': aspect_ratio,
+        'input_images': input_images,
+        'camera_fixed': camera_fixed,
+    }
+
+    # 发送确认请求
+    await send_to_websocket(session_id, {
+        'type': 'tool_call_pending_confirmation',
+        'id': tool_call_id,
+        'name': 'generate_video_by_seedance_v1_pro_volces',
+        'arguments': json.dumps(arguments)
+    })
+
+    # 等待确认
+    confirmed = await tool_confirmation_manager.request_confirmation(
+        tool_call_id, session_id, 'generate_video_by_seedance_v1_pro_volces', arguments
+    )
+
+    if not confirmed:
+        return "Video generation cancelled by user."
+
     # Process input images if provided (only use the first one)
     processed_input_images = None
     if input_images and len(input_images) > 0:


### PR DESCRIPTION
1. 增加了 ToolConfirmationManager ，工具确认管理器；
2. 当调用视频生成工具，添加 request 到 ToolConfirmationManager ，同时发送消息至前端，等待确认；
3. 前端点击确认或取消，再执行接下来 tool 中的视频生成逻辑。 