### PR TITLE
fix: handle malformed node IDs in ComfyUI WebSocket executing events

### DIFF
--- a/server/routers/comfyui_execution.py
+++ b/server/routers/comfyui_execution.py
@@ -270,8 +270,11 @@ class WorkflowExecution:
             if self.current_node:
                 self.remaining_nodes.discard(self.current_node)
                 self.update_overall_progress()
-            self.current_node = data["node"]
-            self.log_node("Executing", data["node"])
+            # Use display_node if available, otherwise use node
+            node_id = data.get("display_node", data.get('node'))
+            
+            self.current_node = node_id
+            self.log_node("Executing", node_id)
             if self.ctx.get("session_id"):
                 await send_to_websocket(
                     self.ctx.get("session_id"),
@@ -279,7 +282,7 @@ class WorkflowExecution:
                         "type": "tool_call_progress",
                         "tool_call_id": self.ctx.get("tool_call_id"),
                         "session_id": self.ctx.get("session_id"),
-                        "update": f"Executing {self.get_node_title(data['node'])}",
+                        "update": f"Executing {self.get_node_title(node_id)}",
                     },
                 )
         return True


### PR DESCRIPTION
ComfyUI sends malformed node IDs (e.g., '9.0.0.1') in 'executing' events  during batched execution, while providing correct IDs in 'display_node' field. Use display_node as primary identifier to prevent KeyError exceptions.