### PR TITLE
feat: support web online

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Server Configuration
+# Set the external server URL for proper image/video display in web interface
+# If not set or empty, defaults to http://localhost:57988
+# Examples:
+# SERVER_URL=http://localhost:57988          # Local development (default)
+# SERVER_URL=https://jaaz.app                # Production with domain  
+# SERVER_URL=http://192.168.1.100:57988      # Docker on remote server
+
+# Leave empty to use default localhost:57988
+SERVER_URL=
+
+# ComfyUI Configuration (if using ComfyUI)
+# For Docker, use host.docker.internal to access host machine
+# COMFYUI_URL=http://host.docker.internal:8188

--- a/server/common.py
+++ b/server/common.py
@@ -1,3 +1,17 @@
 import os
 
 DEFAULT_PORT = int(os.environ.get('DEFAULT_PORT', 57988))
+
+def get_server_url():
+    """Get the server URL from environment or use default localhost"""
+    # Try environment variable first
+    server_url = os.environ.get('SERVER_URL')
+    if server_url and server_url.strip():  # Check for non-empty string
+        print(f"🔗 Using SERVER_URL: {server_url}")
+        return server_url.rstrip('/')
+    
+    # Default to localhost
+    default_url = f"http://localhost:{DEFAULT_PORT}"
+    print(f"🔗 Using default server URL: {default_url}")
+    
+    return default_url

--- a/server/main.py
+++ b/server/main.py
@@ -104,4 +104,4 @@ if __name__ == "__main__":
     import uvicorn
     print("🌟Starting server, UI_DIST_DIR:", os.environ.get('UI_DIST_DIR'))
 
-    uvicorn.run(socket_app, host="127.0.0.1", port=args.port)
+    uvicorn.run(socket_app, host="0.0.0.0", port=args.port)

--- a/server/routers/image_router.py
+++ b/server/routers/image_router.py
@@ -1,6 +1,6 @@
 from fastapi.responses import FileResponse
 from fastapi.concurrency import run_in_threadpool
-from common import DEFAULT_PORT
+from common import DEFAULT_PORT, get_server_url
 from tools.utils.image_canvas_utils import generate_file_id
 from services.config_service import FILES_DIR
 
@@ -91,7 +91,7 @@ async def upload_image(file: UploadFile = File(...), max_size_mb: float = 3.0):
     print('🦄upload_image file_path', file_path)
     return {
         'file_id': f'{file_id}.{extension}',
-        'url': f'http://localhost:{DEFAULT_PORT}/api/file/{file_id}.{extension}',
+        'url': f'{get_server_url()}/api/file/{file_id}.{extension}',
         'width': width,
         'height': height,
     }

--- a/server/tools/comfy_dynamic.py
+++ b/server/tools/comfy_dynamic.py
@@ -26,7 +26,7 @@ import time
 import traceback
 from io import BytesIO
 from typing import Annotated, Any, Dict, List, Optional
-from common import DEFAULT_PORT
+from common import DEFAULT_PORT, get_server_url
 from .utils.image_canvas_utils import (
     generate_file_id,
     generate_new_image_element,
@@ -250,7 +250,7 @@ def build_tool(wf: Dict[str, Any]) -> BaseTool:
                 canvas_data["data"]["elements"].append(new_element)
                 canvas_data["data"]["files"][file_id] = file_data
 
-                image_url = f"http://localhost:{DEFAULT_PORT}/api/file/{filename}"
+                image_url = f"{get_server_url()}/api/file/{filename}"
 
                 generated_files_info.append(
                     {

--- a/server/tools/utils/image_generation_core.py
+++ b/server/tools/utils/image_generation_core.py
@@ -4,7 +4,7 @@ Contains the main orchestration logic for image generation across different prov
 """
 
 from typing import Optional, Dict, Any
-from common import DEFAULT_PORT
+from common import DEFAULT_PORT, get_server_url
 from tools.utils.image_utils import process_input_image
 from ..image_providers.image_base_provider import ImageProviderBase
 
@@ -94,4 +94,4 @@ async def generate_image_with_provider(
         session_id, canvas_id, filename, mime_type, width, height
     )
 
-    return f"image generated successfully ![image_id: {filename}](http://localhost:{DEFAULT_PORT}{image_url})"
+    return f"image generated successfully ![image_id: {filename}]({get_server_url()}{image_url})"

--- a/server/tools/video_generation/video_canvas_utils.py
+++ b/server/tools/video_generation/video_canvas_utils.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Any, Tuple, Optional, Union
 from services.config_service import FILES_DIR
 from services.db_service import db_service
 from services.websocket_service import send_to_websocket, broadcast_session_update  # type: ignore
-from common import DEFAULT_PORT
+from common import DEFAULT_PORT, get_server_url
 from utils.http_client import HttpClient
 import aiofiles
 import mimetypes
@@ -152,7 +152,7 @@ async def send_video_error_notification(session_id: str, error_message: str) -> 
 
 def format_video_success_message(filename: str) -> str:
     """Format success message for video generation"""
-    return f"video generated successfully ![video_id: {filename}](http://localhost:{DEFAULT_PORT}/api/file/{filename})"
+    return f"video generated successfully ![video_id: {filename}]({get_server_url()}/api/file/{filename})"
 
 
 async def process_video_result(


### PR DESCRIPTION
支持web服务通过ip或者域名访问
只要通过环境变量或者.env设置SERVER_URL=即可
之前的web服务只支持本地访问,因为代码里用了硬编码`localhost`和`127.0.0.1`
