### PR TITLE
add multiple languages: french, spanish, korean

### DIFF
--- a/react/src/components/common/LanguageSwitcher.tsx
+++ b/react/src/components/common/LanguageSwitcher.tsx
@@ -16,6 +16,9 @@ const LanguageSwitcher = () => {
   const languages = [
     { code: 'en', name: t('common:languages.en') },
     { code: 'zh-CN', name: t('common:languages.zh-CN') },
+    { code: 'fr', name: t('common:languages.fr') },
+    { code: 'es', name: t('common:languages.es') },
+    { code: 'ko', name: t('common:languages.ko') },
   ]
 
   return (

--- a/react/src/hooks/use-language.ts
+++ b/react/src/hooks/use-language.ts
@@ -14,5 +14,8 @@ export const useLanguage = () => {
     changeLanguage,
     isEnglish: getCurrentLanguage() === 'en',
     isChinese: getCurrentLanguage() === 'zh-CN',
+    isFrench: getCurrentLanguage() === 'fr',
+    isSpanish: getCurrentLanguage() === 'es',
+    isKorean: getCurrentLanguage() === 'ko',
   }
 }

--- a/react/src/i18n/index.ts
+++ b/react/src/i18n/index.ts
@@ -15,6 +15,24 @@ import canvasZh from './locales/zh-CN/canvas.json'
 import chatZh from './locales/zh-CN/chat.json'
 import settingsZh from './locales/zh-CN/settings.json'
 
+import commonFr from './locales/fr/common.json'
+import homeFr from './locales/fr/home.json'
+import canvasFr from './locales/fr/canvas.json'
+import chatFr from './locales/fr/chat.json'
+import settingsFr from './locales/fr/settings.json'
+
+import commonEs from './locales/es/common.json'
+import homeEs from './locales/es/home.json'
+import canvasEs from './locales/es/canvas.json'
+import chatEs from './locales/es/chat.json'
+import settingsEs from './locales/es/settings.json'
+
+import commonKo from './locales/ko/common.json'
+import homeKo from './locales/ko/home.json'
+import canvasKo from './locales/ko/canvas.json'
+import chatKo from './locales/ko/chat.json'
+import settingsKo from './locales/ko/settings.json'
+
 const resources = {
   en: {
     common: commonEn,
@@ -29,6 +47,27 @@ const resources = {
     canvas: canvasZh,
     chat: chatZh,
     settings: settingsZh,
+  },
+  fr: {
+    common: commonFr,
+    home: homeFr,
+    canvas: canvasFr,
+    chat: chatFr,
+    settings: settingsFr,
+  },
+  es: {
+    common: commonEs,
+    home: homeEs,
+    canvas: canvasEs,
+    chat: chatEs,
+    settings: settingsEs,
+  },
+  ko: {
+    common: commonKo,
+    home: homeKo,
+    canvas: canvasKo,
+    chat: chatKo,
+    settings: settingsKo,
   },
 }
 

--- a/react/src/i18n/locales/en/common.json
+++ b/react/src/i18n/locales/en/common.json
@@ -1,7 +1,10 @@
 {
   "languages": {
     "en": "English",
-    "zh-CN": "简体中文"
+    "zh-CN": "简体中文",
+    "fr": "Français",
+    "es": "Español",
+    "ko": "한국어"
   },
   "buttons": {
     "save": "Save",

--- a/react/src/i18n/locales/es/canvas.json
+++ b/react/src/i18n/locales/es/canvas.json
@@ -1,0 +1,63 @@
+{
+  "title": "Lienzo",
+  "rename": "Renombrar lienzo",
+  "delete": "Eliminar lienzo",
+  "share": "Compartir lienzo",
+  "export": "Exportar lienzo",
+  "exportImages": "Exportar",
+  "import": "Importar lienzo",
+  "untitled": "Sin título",
+  "back": "Atrás",
+  "saveSnapshot": "Guardar instantánea",
+  "loadSnapshot": "Cargar instantánea",
+  "saved": "Guardado ✅",
+  "messages": {
+    "canvasRenamed": "Lienzo renombrado con éxito",
+    "canvasDeleted": "Lienzo eliminado con éxito",
+    "canvasExported": "Lienzo exportado con éxito",
+    "canvasImported": "Lienzo importado con éxito",
+    "failedToRename": "Error al renombrar el lienzo",
+    "failedToDelete": "Error al eliminar el lienzo",
+    "failedToCreateFile": "Error al crear el archivo",
+    "nothingSelected": "No hay elementos seleccionados",
+    "exportingAssets": "Exportando elementos...",
+    "failedToExportImages": "Error al exportar imágenes",
+    "gptImagePermissionRequired": "¡Debe habilitar los permisos del modelo gpt-image-1 para usar esta función!"
+  },
+  "deleteDialog": {
+    "title": "Eliminar lienzo",
+    "description": "¿Está seguro de que desea eliminar este lienzo? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "delete": "Eliminar"
+  },
+  "tool": {
+    "hand": "Mano",
+    "selection": "Selección",
+    "rectangle": "Rectángulo",
+    "ellipse": "Elipse",
+    "text": "Texto",
+    "image": "Imagen",
+    "shape": "Forma",
+    "arrow": "Flecha",
+    "line": "Línea",
+    "zoomFit": "Ajustar al tamaño"
+  },
+  "popbar": {
+    "addToChat": "Agregar al chat",
+    "magicGenerate": "✨ Generación mágica"
+  },
+  "myAssets": "Mis elementos",
+  "selectAFolder": "Seleccionar una carpeta",
+  "selectAFolderDescription": "Seleccione una carpeta para ver sus imágenes y videos",
+  "noMediaFiles": "No hay archivos multimedia",
+  "noMediaFilesDescription": "No hay imágenes o videos en esta carpeta",
+  "mediaFiles": "archivos multimedia",
+  "openInExplorer": "Abrir en el explorador de archivos del sistema",
+  "basicInfo": "Información básica",
+  "fileName": "Nombre del archivo",
+  "fileSize": "Tamaño del archivo",
+  "modifiedTime": "Hora de modificación",
+  "dimensions": "Dimensiones",
+  "filePath": "Ruta del archivo",
+  "pngMetadata": "Metadatos PNG"
+}

--- a/react/src/i18n/locales/es/chat.json
+++ b/react/src/i18n/locales/es/chat.json
@@ -1,0 +1,50 @@
+{
+  "newChat": "Nuevo chat",
+  "placeholder": "Escriba su mensaje aquí...",
+  "insufficientBalance": "Saldo insuficiente",
+  "insufficientBalanceDescription": "Sus créditos se han agotado. Por favor recargue para continuar.",
+  "textarea": {
+    "placeholder": "Ingrese sus requisitos de diseño",
+    "selectModel": "¡Por favor seleccione un modelo de texto! Vaya a Configuración para establecer sus claves API si aún no lo ha hecho.",
+    "selectTool": "¡Por favor vaya a configuración para agregar herramientas de generación de imágenes o videos, o no podrá generar ninguna imagen o video!",
+    "enterPrompt": "Por favor ingrese una indicación",
+    "quantity": "Cantidad de imágenes"
+  },
+  "messages": {
+    "imagePositioning": "Ir a la imagen",
+    "showMore": "Mostrar más",
+    "showLess": "Mostrar menos"
+  },
+  "thinking": {
+    "title": "Pensando"
+  },
+  "plan": {
+    "title": "Plan",
+    "steps": {
+      "singular": "paso",
+      "plural": "pasos"
+    }
+  },
+  "shareTemplate": {
+    "title": "Compartir como plantilla",
+    "templateName": "Nombre de la plantilla",
+    "templateNamePlaceholder": "Ingrese el nombre de la plantilla...",
+    "coverPhoto": "Foto de portada",
+    "noImagesFound": "No se encontraron imágenes en el lienzo",
+    "nameRequired": "El nombre de la plantilla es requerido",
+    "coverImageRequired": "La imagen de portada es requerida",
+    "create": "Crear plantilla",
+    "creating": "Creando...",
+    "success": "¡Plantilla creada con éxito!",
+    "error": "Error al crear la plantilla"
+  },
+  "modelSelector": {
+    "title": "Modelo",
+    "auto": "Auto",
+    "tabs": {
+      "image": "Imagen",
+      "video": "Video",
+      "text": "Texto"
+    }
+  }
+}

--- a/react/src/i18n/locales/es/common.json
+++ b/react/src/i18n/locales/es/common.json
@@ -1,0 +1,84 @@
+{
+  "languages": {
+    "en": "English",
+    "zh-CN": "简体中文",
+    "fr": "Français",
+    "es": "Español",
+    "ko": "한국어"
+  },
+  "buttons": {
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "create": "Crear",
+    "submit": "Enviar",
+    "loading": "Cargando...",
+    "retry": "Reintentar"
+  },
+  "common": {
+    "yes": "Sí",
+    "no": "No",
+    "ok": "OK",
+    "error": "Error",
+    "success": "Éxito",
+    "warning": "Advertencia",
+    "info": "Información"
+  },
+  "messages": {
+    "success": "Operación completada con éxito",
+    "error": "Ocurrió un error",
+    "loading": "Cargando, por favor espere...",
+    "noData": "No hay datos disponibles",
+    "confirmDelete": "¿Está seguro de que desea eliminar este elemento?",
+    "saved": "Guardado con éxito",
+    "deleted": "Eliminado con éxito"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "clear": "Limpiar",
+    "markAllAsRead": "Marcar todo como leído",
+    "allRead": "Todo leído",
+    "newImageGenerated": "Nueva imagen generada"
+  },
+  "navigation": {
+    "home": "Inicio",
+    "canvas": "Lienzo",
+    "settings": "Configuración",
+    "back": "Atrás"
+  },
+  "update": {
+    "title": "🎉 Nueva versión disponible",
+    "description": "La nueva versión v{{version}} está disponible. ¿Le gustaría instalarla ahora?",
+    "installNote": "Haga clic en \"Instalar actualización\" para reiniciar la aplicación e instalar la nueva versión.",
+    "laterButton": "Recordar más tarde",
+    "installButton": "Instalar actualización",
+    "installing": "Instalando..."
+  },
+  "auth": {
+    "login": "Iniciar sesión",
+    "logout": "Cerrar sesión",
+    "loginToJaaz": "Iniciar sesión en Jaaz",
+    "myAccount": "Mi cuenta",
+    "loginDescription": "Inicie sesión para usar modelos de IA en la nube",
+    "startLogin": "Comenzar sesión",
+    "preparingLogin": "Preparando inicio de sesión...",
+    "cancel": "Cancelar",
+    "loginSuccessMessage": "¡Inicio de sesión exitoso!",
+    "authExpiredMessage": "Autorización expirada, por favor inicie sesión de nuevo",
+    "authErrorMessage": "Error al verificar el estado de autorización",
+    "waitingForBrowser": "Esperando finalización del inicio de sesión en el navegador...",
+    "pollErrorMessage": "Error al verificar el estado de inicio de sesión, por favor inténtelo de nuevo",
+    "preparingLoginMessage": "Preparando inicio de sesión...",
+    "browserLoginMessage": "Por favor complete el inicio de sesión en el navegador",
+    "loginRequestFailed": "Error en la solicitud de inicio de sesión, por favor inténtelo de nuevo",
+    "logoutSuccessMessage": "Sesión cerrada con éxito",
+    "notLoggedIn": "No ha iniciado sesión",
+    "balance": "Saldo",
+    "recharge": "Recargar"
+  },
+  "socket": {
+    "connectionError": "Error de conexión ({{current}}/{{max}}): {{error}}",
+    "maxRetriesReached": "Error de conexión, por favor reinicie la aplicación"
+  }
+}

--- a/react/src/i18n/locales/es/home.json
+++ b/react/src/i18n/locales/es/home.json
@@ -1,0 +1,7 @@
+{
+  "title": "¡Hola, Jaaz!",
+  "subtitle": "¿Listo para convertir tus ideas en arte?",
+  "allProjects": "Todos los proyectos",
+  "noCanvases": "Aún no hay lienzos",
+  "newCanvas": "Sin título"
+}

--- a/react/src/i18n/locales/es/settings.json
+++ b/react/src/i18n/locales/es/settings.json
@@ -1,0 +1,102 @@
+{
+  "title": "Configuración",
+  "messages": {
+    "settingsSaved": "Configuración guardada con éxito",
+    "settingsReset": "Configuración restablecida a valores predeterminados",
+    "failedToSave": "Error al guardar la configuración",
+    "failedToLoad": "Error al cargar la configuración",
+    "restartRequired": "Por favor reinicie la aplicación para que los ajustes de proxy surtan efecto"
+  },
+  "models": {
+    "title": "Modelos",
+    "placeholder": "Ingrese el nombre del modelo",
+    "addModel": "Agregar modelo",
+    "types": {
+      "text": "texto",
+      "image": "imagen",
+      "video": "video"
+    }
+  },
+  "provider": {
+    "title": "Proveedores",
+    "addProvider": "Agregar proveedor",
+    "providerName": "Nombre del proveedor",
+    "providerNamePlaceholder": "Ingrese el nombre del proveedor",
+    "apiUrl": "URL de la API",
+    "apiUrlPlaceholder": "Ingrese la URL de la API",
+    "apiKey": "Clave API",
+    "apiKeyPlaceholder": "Ingrese la clave API",
+    "apiKeyDescription": "Su clave API será almacenada de forma segura",
+    "maxTokens": "Tokens máximos",
+    "maxTokensPlaceholder": "Ingrese su número máximo de tokens",
+    "maxTokensDescription": "El número máximo de tokens en la respuesta",
+    "customProvider": "✨ Proveedor personalizado",
+    "imageGeneration": "🎨 Generación de imágenes",
+    "delete": "Eliminar",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "noModelsSelected": "Por favor agregue al menos un modelo"
+  },
+  "proxy": {
+    "title": "Configuración de proxy",
+    "mode": "Modo proxy",
+    "selectMode": "Seleccionar modo proxy",
+    "modes": {
+      "no_proxy": "Sin proxy",
+      "system": "Proxy del sistema",
+      "custom": "Proxy personalizado"
+    },
+    "enable": "Habilitar proxy",
+    "url": "URL del proxy",
+    "urlPlaceholder": "http://proxy.example.com:8080",
+    "testConnection": "Probar conexión",
+    "testing": "Probando...",
+    "testSuccess": "Prueba de conexión proxy exitosa",
+    "testFailed": "Error en la prueba de conexión proxy: {{message}}",
+    "testError": "Error en la prueba de conexión proxy",
+    "status": {
+      "enabled": "Habilitado",
+      "disabled": "Deshabilitado",
+      "misconfigured": "Mal configurado"
+    }
+  },
+  "comfyui": {
+    "title": "ComfyUI",
+    "localImageGeneration": "🎨 Generación de imágenes local",
+    "enable": "Habilitar",
+    "debugStatus": "🔍 Estado de depuración",
+    "status": {
+      "disabled": "Deshabilitado",
+      "running": "Ejecutándose",
+      "installed": "Instalado (no ejecutándose)",
+      "notInstalled": "No instalado",
+      "notRunning": "No ejecutándose",
+      "checking": "Verificando..."
+    },
+    "urlDescription": "URL del servicio ComfyUI, ingrese la dirección si ya está instalado",
+    "invalidUrl": "Por favor ingrese una URL válida (ej., http://127.0.0.1:8188)",
+    "notInstalledTitle": "ComfyUI no instalado",
+    "notInstalledDescription": "Instale ComfyUI para habilitar la generación de imágenes local con modelos Flux",
+    "installButton": "Instalar ComfyUI",
+    "startButton": "Iniciar ComfyUI",
+    "uninstallButton": "Desinstalar ComfyUI",
+    "confirmUninstall": "¿Está seguro de que desea desinstalar ComfyUI? Esto eliminará completamente ComfyUI de su sistema, incluyendo todos los modelos descargados y configuraciones.",
+    "confirmUninstallButton": "Confirmar desinstalación",
+    "deleteWorkflowConfirmation": "¿Está seguro de que desea eliminar este flujo de trabajo?",
+    "uninstallProgress": {
+      "title": "Desinstalando ComfyUI",
+      "preparing": "Preparando desinstalación...",
+      "inProgress": "Desinstalación en progreso... Por favor espere.",
+      "logTitle": "Registro de desinstalación:",
+      "completed": "Desinstalación completada"
+    },
+    "notInstalled": "ComfyUI no está instalado",
+    "addWorkflow": "Agregar flujo de trabajo",
+    "addInput": "Agregar entrada",
+    "workflows": "Flujos de trabajo",
+    "editWorkflow": "Editar flujo de trabajo"
+  },
+  "saveSettings": "Guardar configuración",
+  "close": "Cerrar",
+  "cancel": "Cancelar"
+}

--- a/react/src/i18n/locales/fr/canvas.json
+++ b/react/src/i18n/locales/fr/canvas.json
@@ -1,0 +1,63 @@
+{
+  "title": "Canevas",
+  "rename": "Renommer le canevas",
+  "delete": "Supprimer le canevas",
+  "share": "Partager le canevas",
+  "export": "Exporter le canevas",
+  "exportImages": "Exporter",
+  "import": "Importer le canevas",
+  "untitled": "Sans titre",
+  "back": "Retour",
+  "saveSnapshot": "Enregistrer l'instantané",
+  "loadSnapshot": "Charger l'instantané",
+  "saved": "Enregistré ✅",
+  "messages": {
+    "canvasRenamed": "Canevas renommé avec succès",
+    "canvasDeleted": "Canevas supprimé avec succès",
+    "canvasExported": "Canevas exporté avec succès",
+    "canvasImported": "Canevas importé avec succès",
+    "failedToRename": "Échec du renommage du canevas",
+    "failedToDelete": "Échec de la suppression du canevas",
+    "failedToCreateFile": "Échec de la création du fichier",
+    "nothingSelected": "Aucun élément sélectionné",
+    "exportingAssets": "Exportation des éléments...",
+    "failedToExportImages": "Échec de l'exportation des images",
+    "gptImagePermissionRequired": "Vous devez activer les permissions du modèle gpt-image-1 pour utiliser cette fonctionnalité !"
+  },
+  "deleteDialog": {
+    "title": "Supprimer le canevas",
+    "description": "Êtes-vous sûr de vouloir supprimer ce canevas ? Cette action ne peut pas être annulée.",
+    "cancel": "Annuler",
+    "delete": "Supprimer"
+  },
+  "tool": {
+    "hand": "Main",
+    "selection": "Sélection",
+    "rectangle": "Rectangle",
+    "ellipse": "Ellipse",
+    "text": "Texte",
+    "image": "Image",
+    "shape": "Forme",
+    "arrow": "Flèche",
+    "line": "Ligne",
+    "zoomFit": "Ajuster à la taille"
+  },
+  "popbar": {
+    "addToChat": "Ajouter au chat",
+    "magicGenerate": "✨ Génération magique"
+  },
+  "myAssets": "Mes éléments",
+  "selectAFolder": "Sélectionner un dossier",
+  "selectAFolderDescription": "Sélectionnez un dossier pour voir ses images et vidéos",
+  "noMediaFiles": "Aucun fichier média",
+  "noMediaFilesDescription": "Aucune image ou vidéo dans ce dossier",
+  "mediaFiles": "fichiers média",
+  "openInExplorer": "Ouvrir dans l'explorateur de fichiers système",
+  "basicInfo": "Informations de base",
+  "fileName": "Nom du fichier",
+  "fileSize": "Taille du fichier",
+  "modifiedTime": "Heure de modification",
+  "dimensions": "Dimensions",
+  "filePath": "Chemin du fichier",
+  "pngMetadata": "Métadonnées PNG"
+}

--- a/react/src/i18n/locales/fr/chat.json
+++ b/react/src/i18n/locales/fr/chat.json
@@ -1,0 +1,50 @@
+{
+  "newChat": "Nouveau chat",
+  "placeholder": "Tapez votre message ici...",
+  "insufficientBalance": "Solde insuffisant",
+  "insufficientBalanceDescription": "Vos crédits sont épuisés. Veuillez recharger pour continuer.",
+  "textarea": {
+    "placeholder": "Entrez vos exigences de conception",
+    "selectModel": "Veuillez sélectionner un modèle de texte ! Allez dans Paramètres pour définir vos clés API si vous ne l'avez pas encore fait.",
+    "selectTool": "Veuillez aller dans les paramètres pour ajouter des outils de génération d'images ou de vidéos, sinon vous ne pourrez générer aucune image ou vidéo !!",
+    "enterPrompt": "Veuillez entrer une invite",
+    "quantity": "Quantité d'images"
+  },
+  "messages": {
+    "imagePositioning": "Aller à l'image",
+    "showMore": "Afficher plus",
+    "showLess": "Afficher moins"
+  },
+  "thinking": {
+    "title": "Réflexion"
+  },
+  "plan": {
+    "title": "Plan",
+    "steps": {
+      "singular": "étape",
+      "plural": "étapes"
+    }
+  },
+  "shareTemplate": {
+    "title": "Partager comme modèle",
+    "templateName": "Nom du modèle",
+    "templateNamePlaceholder": "Entrez le nom du modèle...",
+    "coverPhoto": "Photo de couverture",
+    "noImagesFound": "Aucune image trouvée dans le canevas",
+    "nameRequired": "Le nom du modèle est requis",
+    "coverImageRequired": "L'image de couverture est requise",
+    "create": "Créer le modèle",
+    "creating": "Création...",
+    "success": "Modèle créé avec succès !",
+    "error": "Échec de la création du modèle"
+  },
+  "modelSelector": {
+    "title": "Modèle",
+    "auto": "Auto",
+    "tabs": {
+      "image": "Image",
+      "video": "Vidéo",
+      "text": "Texte"
+    }
+  }
+}

--- a/react/src/i18n/locales/fr/common.json
+++ b/react/src/i18n/locales/fr/common.json
@@ -1,0 +1,84 @@
+{
+  "languages": {
+    "en": "English",
+    "zh-CN": "简体中文",
+    "fr": "Français",
+    "es": "Español",
+    "ko": "한국어"
+  },
+  "buttons": {
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "create": "Créer",
+    "submit": "Soumettre",
+    "loading": "Chargement...",
+    "retry": "Réessayer"
+  },
+  "common": {
+    "yes": "Oui",
+    "no": "Non",
+    "ok": "OK",
+    "error": "Erreur",
+    "success": "Succès",
+    "warning": "Avertissement",
+    "info": "Information"
+  },
+  "messages": {
+    "success": "Opération terminée avec succès",
+    "error": "Une erreur s'est produite",
+    "loading": "Chargement, veuillez patienter...",
+    "noData": "Aucune donnée disponible",
+    "confirmDelete": "Êtes-vous sûr de vouloir supprimer cet élément ?",
+    "saved": "Enregistré avec succès",
+    "deleted": "Supprimé avec succès"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "clear": "Effacer",
+    "markAllAsRead": "Marquer tout comme lu",
+    "allRead": "Tout lu",
+    "newImageGenerated": "Nouvelle image générée"
+  },
+  "navigation": {
+    "home": "Accueil",
+    "canvas": "Canevas",
+    "settings": "Paramètres",
+    "back": "Retour"
+  },
+  "update": {
+    "title": "🎉 Nouvelle version disponible",
+    "description": "La nouvelle version v{{version}} est disponible. Souhaitez-vous l'installer maintenant ?",
+    "installNote": "Cliquez sur \"Installer la mise à jour\" pour redémarrer l'application et installer la nouvelle version.",
+    "laterButton": "Rappeler plus tard",
+    "installButton": "Installer la mise à jour",
+    "installing": "Installation..."
+  },
+  "auth": {
+    "login": "Connexion",
+    "logout": "Déconnexion",
+    "loginToJaaz": "Se connecter à Jaaz",
+    "myAccount": "Mon compte",
+    "loginDescription": "Connectez-vous pour utiliser les modèles d'IA cloud",
+    "startLogin": "Commencer la connexion",
+    "preparingLogin": "Préparation de la connexion...",
+    "cancel": "Annuler",
+    "loginSuccessMessage": "Connexion réussie !",
+    "authExpiredMessage": "Autorisation expirée, veuillez vous reconnecter",
+    "authErrorMessage": "Erreur lors de la vérification du statut d'autorisation",
+    "waitingForBrowser": "En attente de la finalisation de la connexion dans le navigateur...",
+    "pollErrorMessage": "Échec de la vérification du statut de connexion, veuillez réessayer",
+    "preparingLoginMessage": "Préparation de la connexion...",
+    "browserLoginMessage": "Veuillez finaliser la connexion dans le navigateur",
+    "loginRequestFailed": "Échec de la demande de connexion, veuillez réessayer",
+    "logoutSuccessMessage": "Déconnexion réussie",
+    "notLoggedIn": "Non connecté",
+    "balance": "Solde",
+    "recharge": "Recharger"
+  },
+  "socket": {
+    "connectionError": "Erreur de connexion ({{current}}/{{max}}) : {{error}}",
+    "maxRetriesReached": "Échec de la connexion, veuillez redémarrer l'application"
+  }
+}

--- a/react/src/i18n/locales/fr/home.json
+++ b/react/src/i18n/locales/fr/home.json
@@ -1,0 +1,7 @@
+{
+  "title": "Bonjour, Jaaz !",
+  "subtitle": "Prêt à transformer vos idées en art ?",
+  "allProjects": "Tous les projets",
+  "noCanvases": "Aucun canevas pour le moment",
+  "newCanvas": "Sans titre"
+}

--- a/react/src/i18n/locales/fr/settings.json
+++ b/react/src/i18n/locales/fr/settings.json
@@ -1,0 +1,102 @@
+{
+  "title": "Paramètres",
+  "messages": {
+    "settingsSaved": "Paramètres enregistrés avec succès",
+    "settingsReset": "Paramètres réinitialisés par défaut",
+    "failedToSave": "Échec de l'enregistrement des paramètres",
+    "failedToLoad": "Échec du chargement de la configuration",
+    "restartRequired": "Veuillez redémarrer l'application pour que les paramètres de proxy prennent effet"
+  },
+  "models": {
+    "title": "Modèles",
+    "placeholder": "Entrez le nom du modèle",
+    "addModel": "Ajouter un modèle",
+    "types": {
+      "text": "texte",
+      "image": "image",
+      "video": "vidéo"
+    }
+  },
+  "provider": {
+    "title": "Fournisseurs",
+    "addProvider": "Ajouter un fournisseur",
+    "providerName": "Nom du fournisseur",
+    "providerNamePlaceholder": "Entrez le nom du fournisseur",
+    "apiUrl": "URL de l'API",
+    "apiUrlPlaceholder": "Entrez l'URL de l'API",
+    "apiKey": "Clé API",
+    "apiKeyPlaceholder": "Entrez la clé API",
+    "apiKeyDescription": "Votre clé API sera stockée en sécurité",
+    "maxTokens": "Tokens maximum",
+    "maxTokensPlaceholder": "Entrez votre nombre maximum de tokens",
+    "maxTokensDescription": "Le nombre maximum de tokens dans la réponse",
+    "customProvider": "✨ Fournisseur personnalisé",
+    "imageGeneration": "🎨 Génération d'images",
+    "delete": "Supprimer",
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "noModelsSelected": "Veuillez ajouter au moins un modèle"
+  },
+  "proxy": {
+    "title": "Paramètres de proxy",
+    "mode": "Mode proxy",
+    "selectMode": "Sélectionner le mode proxy",
+    "modes": {
+      "no_proxy": "Aucun proxy",
+      "system": "Proxy système",
+      "custom": "Proxy personnalisé"
+    },
+    "enable": "Activer le proxy",
+    "url": "URL du proxy",
+    "urlPlaceholder": "http://proxy.example.com:8080",
+    "testConnection": "Tester la connexion",
+    "testing": "Test en cours...",
+    "testSuccess": "Test de connexion proxy réussi",
+    "testFailed": "Échec du test de connexion proxy : {{message}}",
+    "testError": "Erreur du test de connexion proxy",
+    "status": {
+      "enabled": "Activé",
+      "disabled": "Désactivé",
+      "misconfigured": "Mal configuré"
+    }
+  },
+  "comfyui": {
+    "title": "ComfyUI",
+    "localImageGeneration": "🎨 Génération d'images locale",
+    "enable": "Activer",
+    "debugStatus": "🔍 Statut de débogage",
+    "status": {
+      "disabled": "Désactivé",
+      "running": "En cours d'exécution",
+      "installed": "Installé (non en cours d'exécution)",
+      "notInstalled": "Non installé",
+      "notRunning": "Non en cours d'exécution",
+      "checking": "Vérification..."
+    },
+    "urlDescription": "URL du service ComfyUI, entrez l'adresse si déjà installé",
+    "invalidUrl": "Veuillez entrer une URL valide (par ex., http://127.0.0.1:8188)",
+    "notInstalledTitle": "ComfyUI non installé",
+    "notInstalledDescription": "Installez ComfyUI pour activer la génération d'images locale avec les modèles Flux",
+    "installButton": "Installer ComfyUI",
+    "startButton": "Démarrer ComfyUI",
+    "uninstallButton": "Désinstaller ComfyUI",
+    "confirmUninstall": "Êtes-vous sûr de vouloir désinstaller ComfyUI ? Cela supprimera complètement ComfyUI de votre système, y compris tous les modèles téléchargés et configurations.",
+    "confirmUninstallButton": "Confirmer la désinstallation",
+    "deleteWorkflowConfirmation": "Êtes-vous sûr de vouloir supprimer ce flux de travail ?",
+    "uninstallProgress": {
+      "title": "Désinstallation de ComfyUI",
+      "preparing": "Préparation de la désinstallation...",
+      "inProgress": "Désinstallation en cours... Veuillez patienter.",
+      "logTitle": "Journal de désinstallation :",
+      "completed": "Désinstallation terminée"
+    },
+    "notInstalled": "ComfyUI n'est pas installé",
+    "addWorkflow": "Ajouter un flux de travail",
+    "addInput": "Ajouter une entrée",
+    "workflows": "Flux de travail",
+    "editWorkflow": "Modifier le flux de travail"
+  },
+  "saveSettings": "Enregistrer les paramètres",
+  "close": "Fermer",
+  "cancel": "Annuler"
+}

--- a/react/src/i18n/locales/ko/canvas.json
+++ b/react/src/i18n/locales/ko/canvas.json
@@ -1,0 +1,63 @@
+{
+  "title": "캔버스",
+  "rename": "캔버스 이름 바꾸기",
+  "delete": "캔버스 삭제",
+  "share": "캔버스 공유",
+  "export": "캔버스 내보내기",
+  "exportImages": "내보내기",
+  "import": "캔버스 가져오기",
+  "untitled": "제목 없음",
+  "back": "뒤로",
+  "saveSnapshot": "스냅샷 저장",
+  "loadSnapshot": "스냅샷 불러오기",
+  "saved": "저장됨 ✅",
+  "messages": {
+    "canvasRenamed": "캔버스 이름이 성공적으로 변경되었습니다",
+    "canvasDeleted": "캔버스가 성공적으로 삭제되었습니다",
+    "canvasExported": "캔버스가 성공적으로 내보내졌습니다",
+    "canvasImported": "캔버스가 성공적으로 가져와졌습니다",
+    "failedToRename": "캔버스 이름 변경에 실패했습니다",
+    "failedToDelete": "캔버스 삭제에 실패했습니다",
+    "failedToCreateFile": "파일 생성에 실패했습니다",
+    "nothingSelected": "선택된 항목이 없습니다",
+    "exportingAssets": "요소를 내보내는 중...",
+    "failedToExportImages": "이미지 내보내기에 실패했습니다",
+    "gptImagePermissionRequired": "이 기능을 사용하려면 gpt-image-1 모델 권한을 활성화해야 합니다!"
+  },
+  "deleteDialog": {
+    "title": "캔버스 삭제",
+    "description": "이 캔버스를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+    "cancel": "취소",
+    "delete": "삭제"
+  },
+  "tool": {
+    "hand": "손",
+    "selection": "선택",
+    "rectangle": "직사각형",
+    "ellipse": "타원",
+    "text": "텍스트",
+    "image": "이미지",
+    "shape": "도형",
+    "arrow": "화살표",
+    "line": "선",
+    "zoomFit": "화면에 맞춤"
+  },
+  "popbar": {
+    "addToChat": "채팅에 추가",
+    "magicGenerate": "✨ 마법 생성"
+  },
+  "myAssets": "내 요소",
+  "selectAFolder": "폴더 선택",
+  "selectAFolderDescription": "이미지와 비디오를 보려면 폴더를 선택하세요",
+  "noMediaFiles": "미디어 파일 없음",
+  "noMediaFilesDescription": "이 폴더에 이미지나 비디오가 없습니다",
+  "mediaFiles": "미디어 파일",
+  "openInExplorer": "시스템 파일 탐색기에서 열기",
+  "basicInfo": "기본 정보",
+  "fileName": "파일 이름",
+  "fileSize": "파일 크기",
+  "modifiedTime": "수정 시간",
+  "dimensions": "크기",
+  "filePath": "파일 경로",
+  "pngMetadata": "PNG 메타데이터"
+}

--- a/react/src/i18n/locales/ko/chat.json
+++ b/react/src/i18n/locales/ko/chat.json
@@ -1,0 +1,50 @@
+{
+  "newChat": "새 채팅",
+  "placeholder": "여기에 메시지를 입력하세요...",
+  "insufficientBalance": "잔액 부족",
+  "insufficientBalanceDescription": "크레딧이 부족합니다. 계속하려면 충전해주세요.",
+  "textarea": {
+    "placeholder": "디자인 요구사항을 입력하세요",
+    "selectModel": "텍스트 모델을 선택해주세요! 아직 설정하지 않았다면 설정에서 API 키를 설정하세요.",
+    "selectTool": "이미지나 비디오 생성 도구를 추가하려면 설정으로 이동하세요. 그렇지 않으면 이미지나 비디오를 생성할 수 없습니다!",
+    "enterPrompt": "프롬프트를 입력해주세요",
+    "quantity": "이미지 수량"
+  },
+  "messages": {
+    "imagePositioning": "이미지로 이동",
+    "showMore": "더 보기",
+    "showLess": "줄이기"
+  },
+  "thinking": {
+    "title": "생각 중"
+  },
+  "plan": {
+    "title": "계획",
+    "steps": {
+      "singular": "단계",
+      "plural": "단계"
+    }
+  },
+  "shareTemplate": {
+    "title": "템플릿으로 공유",
+    "templateName": "템플릿 이름",
+    "templateNamePlaceholder": "템플릿 이름을 입력하세요...",
+    "coverPhoto": "커버 사진",
+    "noImagesFound": "캔버스에서 이미지를 찾을 수 없습니다",
+    "nameRequired": "템플릿 이름이 필요합니다",
+    "coverImageRequired": "커버 이미지가 필요합니다",
+    "create": "템플릿 생성",
+    "creating": "생성 중...",
+    "success": "템플릿이 성공적으로 생성되었습니다!",
+    "error": "템플릿 생성에 실패했습니다"
+  },
+  "modelSelector": {
+    "title": "모델",
+    "auto": "자동",
+    "tabs": {
+      "image": "이미지",
+      "video": "비디오",
+      "text": "텍스트"
+    }
+  }
+}

--- a/react/src/i18n/locales/ko/common.json
+++ b/react/src/i18n/locales/ko/common.json
@@ -1,0 +1,84 @@
+{
+  "languages": {
+    "en": "English",
+    "zh-CN": "简体中文",
+    "fr": "Français",
+    "es": "Español",
+    "ko": "한국어"
+  },
+  "buttons": {
+    "save": "저장",
+    "cancel": "취소",
+    "delete": "삭제",
+    "edit": "편집",
+    "create": "생성",
+    "submit": "제출",
+    "loading": "로딩 중...",
+    "retry": "다시 시도"
+  },
+  "common": {
+    "yes": "예",
+    "no": "아니오",
+    "ok": "확인",
+    "error": "오류",
+    "success": "성공",
+    "warning": "경고",
+    "info": "정보"
+  },
+  "messages": {
+    "success": "작업이 성공적으로 완료되었습니다",
+    "error": "오류가 발생했습니다",
+    "loading": "로딩 중입니다. 잠시만 기다려주세요...",
+    "noData": "사용 가능한 데이터가 없습니다",
+    "confirmDelete": "이 항목을 삭제하시겠습니까?",
+    "saved": "성공적으로 저장되었습니다",
+    "deleted": "성공적으로 삭제되었습니다"
+  },
+  "notifications": {
+    "title": "알림",
+    "clear": "지우기",
+    "markAllAsRead": "모두 읽음으로 표시",
+    "allRead": "모두 읽음",
+    "newImageGenerated": "새 이미지가 생성되었습니다"
+  },
+  "navigation": {
+    "home": "홈",
+    "canvas": "캔버스",
+    "settings": "설정",
+    "back": "뒤로"
+  },
+  "update": {
+    "title": "🎉 새 버전이 사용 가능합니다",
+    "description": "새 버전 v{{version}}이 사용 가능합니다. 지금 설치하시겠습니까?",
+    "installNote": "\"업데이트 설치\"를 클릭하여 앱을 다시 시작하고 새 버전을 설치하세요.",
+    "laterButton": "나중에 알림",
+    "installButton": "업데이트 설치",
+    "installing": "설치 중..."
+  },
+  "auth": {
+    "login": "로그인",
+    "logout": "로그아웃",
+    "loginToJaaz": "Jaaz에 로그인",
+    "myAccount": "내 계정",
+    "loginDescription": "클라우드 AI 모델을 사용하려면 로그인하세요",
+    "startLogin": "로그인 시작",
+    "preparingLogin": "로그인 준비 중...",
+    "cancel": "취소",
+    "loginSuccessMessage": "로그인 성공!",
+    "authExpiredMessage": "인증이 만료되었습니다. 다시 로그인해주세요",
+    "authErrorMessage": "인증 상태 확인 중 오류가 발생했습니다",
+    "waitingForBrowser": "브라우저에서 로그인 완료를 기다리는 중...",
+    "pollErrorMessage": "로그인 상태 확인에 실패했습니다. 다시 시도해주세요",
+    "preparingLoginMessage": "로그인 준비 중...",
+    "browserLoginMessage": "브라우저에서 로그인을 완료해주세요",
+    "loginRequestFailed": "로그인 요청이 실패했습니다. 다시 시도해주세요",
+    "logoutSuccessMessage": "성공적으로 로그아웃되었습니다",
+    "notLoggedIn": "로그인되지 않음",
+    "balance": "잔액",
+    "recharge": "충전"
+  },
+  "socket": {
+    "connectionError": "연결 오류 ({{current}}/{{max}}): {{error}}",
+    "maxRetriesReached": "연결 실패, 애플리케이션을 다시 시작해주세요"
+  }
+}

--- a/react/src/i18n/locales/ko/home.json
+++ b/react/src/i18n/locales/ko/home.json
@@ -1,0 +1,7 @@
+{
+  "title": "안녕하세요, Jaaz!",
+  "subtitle": "아이디어를 예술로 바꿀 준비가 되셨나요?",
+  "allProjects": "모든 프로젝트",
+  "noCanvases": "아직 캔버스가 없습니다",
+  "newCanvas": "제목 없음"
+}

--- a/react/src/i18n/locales/ko/settings.json
+++ b/react/src/i18n/locales/ko/settings.json
@@ -1,0 +1,102 @@
+{
+  "title": "설정",
+  "messages": {
+    "settingsSaved": "설정이 성공적으로 저장되었습니다",
+    "settingsReset": "설정이 기본값으로 재설정되었습니다",
+    "failedToSave": "설정 저장에 실패했습니다",
+    "failedToLoad": "구성 로드에 실패했습니다",
+    "restartRequired": "프록시 설정이 적용되려면 애플리케이션을 다시 시작해주세요"
+  },
+  "models": {
+    "title": "모델",
+    "placeholder": "모델 이름을 입력하세요",
+    "addModel": "모델 추가",
+    "types": {
+      "text": "텍스트",
+      "image": "이미지",
+      "video": "비디오"
+    }
+  },
+  "provider": {
+    "title": "제공업체",
+    "addProvider": "제공업체 추가",
+    "providerName": "제공업체 이름",
+    "providerNamePlaceholder": "제공업체 이름을 입력하세요",
+    "apiUrl": "API URL",
+    "apiUrlPlaceholder": "API URL을 입력하세요",
+    "apiKey": "API 키",
+    "apiKeyPlaceholder": "API 키를 입력하세요",
+    "apiKeyDescription": "API 키는 안전하게 저장됩니다",
+    "maxTokens": "최대 토큰",
+    "maxTokensPlaceholder": "최대 토큰 수를 입력하세요",
+    "maxTokensDescription": "응답의 최대 토큰 수",
+    "customProvider": "✨ 커스텀 제공업체",
+    "imageGeneration": "🎨 이미지 생성",
+    "delete": "삭제",
+    "save": "저장",
+    "cancel": "취소",
+    "noModelsSelected": "최소 하나의 모델을 추가해주세요"
+  },
+  "proxy": {
+    "title": "프록시 설정",
+    "mode": "프록시 모드",
+    "selectMode": "프록시 모드 선택",
+    "modes": {
+      "no_proxy": "프록시 없음",
+      "system": "시스템 프록시",
+      "custom": "커스텀 프록시"
+    },
+    "enable": "프록시 활성화",
+    "url": "프록시 URL",
+    "urlPlaceholder": "http://proxy.example.com:8080",
+    "testConnection": "연결 테스트",
+    "testing": "테스트 중...",
+    "testSuccess": "프록시 연결 테스트 성공",
+    "testFailed": "프록시 연결 테스트 실패: {{message}}",
+    "testError": "프록시 연결 테스트 오류",
+    "status": {
+      "enabled": "활성화됨",
+      "disabled": "비활성화됨",
+      "misconfigured": "잘못 구성됨"
+    }
+  },
+  "comfyui": {
+    "title": "ComfyUI",
+    "localImageGeneration": "🎨 로컬 이미지 생성",
+    "enable": "활성화",
+    "debugStatus": "🔍 디버그 상태",
+    "status": {
+      "disabled": "비활성화됨",
+      "running": "실행 중",
+      "installed": "설치됨 (실행되지 않음)",
+      "notInstalled": "설치되지 않음",
+      "notRunning": "실행되지 않음",
+      "checking": "확인 중..."
+    },
+    "urlDescription": "ComfyUI 서비스 URL, 이미 설치된 경우 주소를 입력하세요",
+    "invalidUrl": "유효한 URL을 입력해주세요 (예: http://127.0.0.1:8188)",
+    "notInstalledTitle": "ComfyUI가 설치되지 않음",
+    "notInstalledDescription": "Flux 모델로 로컬 이미지 생성을 활성화하려면 ComfyUI를 설치하세요",
+    "installButton": "ComfyUI 설치",
+    "startButton": "ComfyUI 시작",
+    "uninstallButton": "ComfyUI 제거",
+    "confirmUninstall": "ComfyUI를 제거하시겠습니까? 이렇게 하면 다운로드된 모든 모델과 구성을 포함하여 시스템에서 ComfyUI가 완전히 제거됩니다.",
+    "confirmUninstallButton": "제거 확인",
+    "deleteWorkflowConfirmation": "이 워크플로를 삭제하시겠습니까?",
+    "uninstallProgress": {
+      "title": "ComfyUI 제거 중",
+      "preparing": "제거 준비 중...",
+      "inProgress": "제거 진행 중... 잠시만 기다려주세요.",
+      "logTitle": "제거 로그:",
+      "completed": "제거 완료"
+    },
+    "notInstalled": "ComfyUI가 설치되지 않았습니다",
+    "addWorkflow": "워크플로 추가",
+    "addInput": "입력 추가",
+    "workflows": "워크플로",
+    "editWorkflow": "워크플로 편집"
+  },
+  "saveSettings": "설정 저장",
+  "close": "닫기",
+  "cancel": "취소"
+}

--- a/react/src/i18n/locales/zh-CN/common.json
+++ b/react/src/i18n/locales/zh-CN/common.json
@@ -1,7 +1,10 @@
 {
   "languages": {
     "en": "English",
-    "zh-CN": "简体中文"
+    "zh-CN": "简体中文",
+    "fr": "Français",
+    "es": "Español",
+    "ko": "한국어"
   },
   "buttons": {
     "save": "保存",


### PR DESCRIPTION
## Add Multi-Language Support (French, Spanish, Korean)

### Changed
- added French (fr) language support with complete translations
- added Spanish (es) language support with complete translations  
- added Korean (ko) language support with complete translations
- updated language switcher to include new languages
- enhanced useLanguage hook with language detection helpers
- updated i18n configuration for all new languages

### Added
- `src/i18n/locales/fr/` - Complete French translations
- `src/i18n/locales/es/` - Complete Spanish translations
- `src/i18n/locales/ko/` - Complete Korean translations

### Modified
- `src/i18n/index.ts` - Added new language imports and resources
- `src/components/common/LanguageSwitcher.tsx` - Added new language options
- `src/hooks/use-language.ts` - Added language detection helpers
- all existing locale files - Added new language names