### PR TITLE
fix: sanitize HTML error responses and remove duplicate done event

### DIFF
--- a/server/services/langgraph_service/StreamProcessor.py
+++ b/server/services/langgraph_service/StreamProcessor.py
@@ -36,11 +36,6 @@ class StreamProcessor:
         ):
             await self._handle_chunk(chunk)
 
-        # 发送完成事件
-        await self.websocket_service(self.session_id, {
-            'type': 'done'
-        })
-
     async def _handle_chunk(self, chunk: Any) -> None:
         # print('👇chunk', chunk)
         """处理单个chunk"""

--- a/server/services/langgraph_service/agent_service.py
+++ b/server/services/langgraph_service/agent_service.py
@@ -174,7 +174,19 @@ async def _handle_error(error: Exception, session_id: str) -> None:
     print(f"Full traceback:\n{tb_str}")
     traceback.print_exc()
 
+    error_str = str(error)
+    # Sanitize HTML error responses (e.g., Cloudflare blocks, gateway error pages)
+    # that occur when the API endpoint returns an HTML page instead of JSON
+    if error_str.strip().startswith('<'):
+        error_str = (
+            'The API request was blocked or returned an unexpected response. '
+            'This may be caused by a firewall, rate limit, or network issue. '
+            'Please check your API key, network settings, and try again.'
+        )
+    elif len(error_str) > 1000:
+        error_str = error_str[:1000] + '...'
+
     await send_to_websocket(session_id, cast(Dict[str, Any], {
         'type': 'error',
-        'error': str(error)
+        'error': error_str
     }))


### PR DESCRIPTION
Fixes #258

## Problem

When the Jaaz API is blocked by Cloudflare or other intermediaries (firewalls, rate limiters), the OpenAI SDK raises a `PermissionDeniedError` whose string representation contains the full HTML error page. This page is then forwarded verbatim to the frontend as the error message, showing users a wall of raw HTML markup instead of a helpful, actionable message.

Example of what users see in the error toast:
```
Error: <!DOCTYPE html><!--[if lt IE 7]>...Sorry, you have been blocked...Cloudflare Ray ID...
```

## Solution

**1. Sanitize HTML error responses in `_handle_error`**

Detect when the error string starts with `<` (HTML content) and replace it with a clear, user-friendly message that explains what likely happened and what to do. Also truncate any excessively long error strings (> 1000 chars) to prevent the UI from being flooded.

**2. Remove duplicate `done` event from `StreamProcessor.process_stream`**

`chat_service.py` already sends a `done` event in its `finally` block, which runs regardless of success, error, or cancellation. `StreamProcessor` was also sending its own `done` at the end of a successful stream, causing the frontend to receive the event twice on success. Removing the redundant one from `StreamProcessor` keeps the control flow clean.

## Testing

- Start the server and trigger an API call that returns an HTML error page (e.g., block the API endpoint at the firewall level)
- Verify the frontend shows the clean error message instead of raw HTML
- Normal successful chat flows should be unaffected