### PR TITLE
feat(config): add Atlas Cloud provider preset

### DIFF
--- a/server/services/config_service.py
+++ b/server/services/config_service.py
@@ -59,6 +59,14 @@ DEFAULT_PROVIDERS_CONFIG: AppConfig = {
         'api_key': '',
         'max_tokens': 8192,
     },
+    'atlascloud': {
+        'models': {
+            'deepseek-ai/deepseek-v4-pro': {'type': 'text'},
+        },
+        'url': 'https://api.atlascloud.ai/v1/',
+        'api_key': '',
+        'max_tokens': 8192,
+    },
 
 }
 

--- a/server/services/test_config_service.py
+++ b/server/services/test_config_service.py
@@ -1,0 +1,20 @@
+import unittest
+
+from services.config_service import DEFAULT_PROVIDERS_CONFIG
+
+
+class DefaultProvidersConfigTest(unittest.TestCase):
+    def test_atlascloud_provider_uses_openai_compatible_defaults(self):
+        provider = DEFAULT_PROVIDERS_CONFIG['atlascloud']
+
+        self.assertEqual(provider['url'], 'https://api.atlascloud.ai/v1/')
+        self.assertEqual(provider['api_key'], '')
+        self.assertEqual(provider['max_tokens'], 8192)
+        self.assertEqual(
+            provider['models'],
+            {'deepseek-ai/deepseek-v4-pro': {'type': 'text'}},
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an `atlascloud` provider preset to the existing OpenAI-compatible configuration path
- default to `https://api.atlascloud.ai/v1/` and `deepseek-ai/deepseek-v4-pro`
- keep credentials empty so users supply their own API key in settings

## Validation
- `python3 -m unittest server.services.test_config_service`
- `python3 -m compileall -q server/services/config_service.py server/services/test_config_service.py`
- Ruff passed after excluding two pre-existing `config_service.py` findings (`I001`, `UP015`)
- `git diff --check`
- Atlas Cloud model catalog and live chat completion returned HTTP 200

## Scope
No README, documentation, logo, sponsor, credits, or partner promotion changes.