### PR TITLE
feat: add MiniMax provider presets with global and CN endpoints

### DIFF
--- a/react/src/components/settings/AddProviderDialog.tsx
+++ b/react/src/components/settings/AddProviderDialog.tsx
@@ -116,6 +116,28 @@ const PROVIDER_OPTIONS = [
     },
   },
   {
+    value: 'minimax',
+    label: 'MiniMax',
+    data: {
+      apiUrl: 'https://api.minimax.io/v1/',
+      models: {
+        'MiniMax-M3': { type: 'text' },
+        'MiniMax-M2.7': { type: 'text' },
+      },
+    },
+  },
+  {
+    value: 'minimax_cn',
+    label: 'MiniMax (China)',
+    data: {
+      apiUrl: 'https://api.minimaxi.com/v1/',
+      models: {
+        'MiniMax-M3': { type: 'text' },
+        'MiniMax-M2.7': { type: 'text' },
+      },
+    },
+  },
+  {
     value: '硅基流动',
     label: '硅基流动 (SiliconFlow)',
     data: { apiUrl: 'https://api.siliconflow.cn/v1/' },

--- a/react/src/constants.ts
+++ b/react/src/constants.ts
@@ -40,6 +40,14 @@ export const PROVIDER_NAME_MAPPING: {
     name: 'ComfyUI',
     icon: 'https://framerusercontent.com/images/3cNQMWKzIhIrQ5KErBm7dSmbd2w.png',
   },
+  minimax: {
+    name: 'MiniMax',
+    icon: 'https://platform.minimax.io/favicon.ico',
+  },
+  minimax_cn: {
+    name: 'MiniMax (China)',
+    icon: 'https://platform.minimaxi.com/favicon.ico',
+  },
 }
 
 // Tool call name mapping


### PR DESCRIPTION
Reason: The built-in provider preset registry had no MiniMax entry, so users had to type endpoints and model names by hand to reach MiniMax models.

## Changes

- Add MiniMax presets to the provider selection registry in `react/src/components/settings/AddProviderDialog.tsx`. Two presets are provided, one for the global endpoint (`https://api.minimax.io/v1/`) and one for the China endpoint (`https://api.minimaxi.com/v1/`), each preloaded with the current `MiniMax-M3` and `MiniMax-M2.7` text models.
- Register the two presets in `PROVIDER_NAME_MAPPING` (`react/src/constants.ts`) with display names and icons so they render with proper labels in the settings and model-selector UI.

This follows the existing pattern for named providers in the repository, which are declared as presets on the frontend and consumed at runtime as custom providers; no backend default or new dependency is required.

## Checks

- `npx tsc -b` (in `react/`): the two changed files introduce no new type errors; the remaining errors are pre-existing and confined to unrelated files.
- `npx eslint src/components/settings/AddProviderDialog.tsx src/constants.ts` (in `react/`): the added entries are lint-clean; the single reported error is a pre-existing `any` on an unrelated line.
