### PR TITLE
Add MiniMax H3 video provider

### DIFF
--- a/server/services/config_service.py
+++ b/server/services/config_service.py
@@ -59,6 +59,13 @@ DEFAULT_PROVIDERS_CONFIG: AppConfig = {
         'api_key': '',
         'max_tokens': 8192,
     },
+    'minimax': {
+        'models': {
+            'MiniMax-H3': {'type': 'video'},
+        },
+        'url': 'https://api.minimax.io',
+        'api_key': '',
+    },
 
 }
 

--- a/server/services/tool_service.py
+++ b/server/services/tool_service.py
@@ -49,6 +49,7 @@ from tools.generate_image_by_recraft_v3_replicate import (
     generate_image_by_recraft_v3_replicate,
 )
 from tools.generate_video_by_hailuo_02_jaaz import generate_video_by_hailuo_02_jaaz
+from tools.generate_video_by_minimax_h3_jaaz import generate_video_by_minimax_h3_jaaz
 from tools.generate_video_by_veo3_fast_jaaz import generate_video_by_veo3_fast_jaaz
 from tools.generate_image_by_midjourney_jaaz import generate_image_by_midjourney_jaaz
 from services.config_service import config_service
@@ -132,6 +133,12 @@ TOOL_MAPPING: Dict[str, ToolInfo] = {
         "type": "video",
         "provider": "jaaz",
         "tool_function": generate_video_by_hailuo_02_jaaz,
+    },
+    "generate_video_by_minimax_h3_jaaz": {
+        "display_name": "MiniMax H3",
+        "type": "video",
+        "provider": "minimax",
+        "tool_function": generate_video_by_minimax_h3_jaaz,
     },
     "generate_video_by_kling_v2_jaaz": {
         "display_name": "Kling v2.1 Standard",

--- a/server/tests/test_minimax_provider.py
+++ b/server/tests/test_minimax_provider.py
@@ -1,0 +1,85 @@
+import pytest
+
+from services.config_service import config_service
+from tools.video_providers.minimax_provider import MiniMaxVideoProvider
+
+
+def make_provider(monkeypatch, url: str = "https://api.minimax.io") -> MiniMaxVideoProvider:
+    monkeypatch.setitem(
+        config_service.app_config,
+        "minimax",
+        {
+            "api_key": "test-key",
+            "url": url,
+            "model_name": "MiniMax-H3",
+        },
+    )
+    return MiniMaxVideoProvider()
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://api.minimax.io", "https://api.minimax.io/v2/video_generation"),
+        ("https://api.minimax.io/v2", "https://api.minimax.io/v2/video_generation"),
+        (
+            "https://api.minimax.io/v2/video_generation",
+            "https://api.minimax.io/v2/video_generation",
+        ),
+    ],
+)
+def test_minimax_builds_video_endpoint(monkeypatch, url: str, expected: str):
+    provider = make_provider(monkeypatch, url)
+    assert provider._build_api_url() == expected
+
+
+def test_minimax_builds_frame_roles(monkeypatch):
+    provider = make_provider(monkeypatch)
+    content = provider._build_content(
+        "A cinematic scene",
+        input_images=["data:image/png;base64,one", "data:image/png;base64,two"],
+    )
+
+    assert content[0] == {"type": "text", "text": "A cinematic scene"}
+    assert content[1]["role"] == "first_frame"
+    assert content[2]["role"] == "last_frame"
+
+
+def test_minimax_builds_reference_roles(monkeypatch):
+    provider = make_provider(monkeypatch)
+    content = provider._build_content(
+        "A cinematic scene",
+        reference_images=["data:image/png;base64,one"],
+        reference_videos=["https://example.com/ref.mp4"],
+        reference_audios=["https://example.com/ref.mp3"],
+    )
+
+    roles = [item.get("role") for item in content[1:]]
+    assert roles == ["reference_image", "reference_video", "reference_audio"]
+
+
+def test_minimax_rejects_mixed_roles(monkeypatch):
+    provider = make_provider(monkeypatch)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        provider._build_content(
+            "A cinematic scene",
+            input_images=["data:image/png;base64,one"],
+            reference_images=["data:image/png;base64,two"],
+        )
+
+
+@pytest.mark.parametrize(
+    ("resolution", "duration", "ratio", "message"),
+    [
+        ("1080p", 5, "16:9", "2K resolution"),
+        ("2K", 3, "16:9", "between 4 and 15"),
+        ("2K", 5, "adaptive", "concrete ratio"),
+    ],
+)
+def test_minimax_validates_request(monkeypatch, resolution, duration, ratio, message):
+    provider = make_provider(monkeypatch)
+    content = provider._build_content("A cinematic scene")
+
+    with pytest.raises(ValueError, match=message):
+        provider._validate_request(resolution, duration, ratio, content)

--- a/server/tests/test_minimax_provider.py
+++ b/server/tests/test_minimax_provider.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from services.config_service import config_service
@@ -26,11 +28,93 @@ def make_provider(monkeypatch, url: str = "https://api.minimax.io") -> MiniMaxVi
             "https://api.minimax.io/v2/video_generation",
             "https://api.minimax.io/v2/video_generation",
         ),
+        (
+            "https://api.minimaxi.com",
+            "https://api.minimaxi.com/v2/video_generation",
+        ),
     ],
 )
 def test_minimax_builds_video_endpoint(monkeypatch, url: str, expected: str):
     provider = make_provider(monkeypatch, url)
     assert provider._build_api_url() == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (
+            "/query/video_generation/task-123",
+            "https://api.minimax.io/v2/query/video_generation/task-123",
+        ),
+        (
+            "/query/video_generation",
+            "https://api.minimax.io/v2/query/video_generation",
+        ),
+        (
+            "/video_generation/task-123",
+            "https://api.minimax.io/v2/video_generation/task-123",
+        ),
+    ],
+)
+def test_minimax_builds_operation_endpoints(monkeypatch, path: str, expected: str):
+    provider = make_provider(monkeypatch)
+    assert provider._build_api_url(path) == expected
+
+
+def test_minimax_uses_v2_operation_paths(monkeypatch):
+    provider = make_provider(monkeypatch)
+    requests = []
+
+    class SessionContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    async def fake_request_json(
+        session, method, path, headers, payload=None, params=None
+    ):
+        requests.append((method, path, payload, params))
+        if path.endswith("task-poll"):
+            return {
+                "task": {
+                    "status": "succeeded",
+                    "content": {"url": "https://example.com/video.mp4"},
+                }
+            }
+        return {"task_id": "task-123"}
+
+    monkeypatch.setattr(provider, "_request_json", fake_request_json)
+    monkeypatch.setattr(
+        "tools.video_providers.minimax_provider.HttpClient.create_aiohttp",
+        lambda: SessionContext(),
+    )
+
+    async def exercise_operations():
+        await provider.create_video_generation_task(
+            content=[{"type": "text", "text": "A cinematic scene"}],
+            resolution="2K",
+            duration=5,
+            ratio="16:9",
+        )
+        await provider.query_video_generation_task("task-123")
+        await provider.list_video_generation_tasks()
+        await provider.delete_video_generation_task("task-123")
+        assert (
+            await provider._poll_for_task_completion("task-poll")
+            == "https://example.com/video.mp4"
+        )
+
+    asyncio.run(exercise_operations())
+
+    assert [(method, path) for method, path, _, _ in requests] == [
+        ("POST", "/video_generation"),
+        ("GET", "/query/video_generation/task-123"),
+        ("GET", "/query/video_generation"),
+        ("DELETE", "/video_generation/task-123"),
+        ("GET", "/query/video_generation/task-poll"),
+    ]
 
 
 def test_minimax_builds_frame_roles(monkeypatch):

--- a/server/tools/generate_video_by_minimax_h3_jaaz.py
+++ b/server/tools/generate_video_by_minimax_h3_jaaz.py
@@ -1,0 +1,77 @@
+from typing import Annotated
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import InjectedToolCallId, tool  # type: ignore
+from pydantic import BaseModel, Field
+
+from .utils.image_utils import process_input_image
+from .video_generation import generate_video_with_provider
+
+
+class GenerateVideoByMiniMaxH3InputSchema(BaseModel):
+    prompt: str = Field(
+        description="Required. The prompt for video generation. Describe the scene clearly."
+    )
+    resolution: str = Field(
+        default="2K",
+        description="Optional. The only supported resolution is 2K.",
+    )
+    duration: int = Field(
+        default=5,
+        description="Optional. Duration in seconds. Allowed values are 4 through 15.",
+    )
+    ratio: str = Field(
+        default="16:9",
+        description="Optional. The aspect ratio. Allowed values are adaptive, 21:9, 16:9, 4:3, 1:1, 3:4, 9:16.",
+    )
+    input_images: list[str] | None = Field(
+        default=None,
+        description="Optional. Images to use as frame or reference inputs. One image uses the first frame role; two images use first and last frame roles.",
+    )
+    callback_url: str | None = Field(
+        default=None,
+        description="Optional. Callback URL for task updates.",
+    )
+    tool_call_id: Annotated[str, InjectedToolCallId]
+
+
+@tool(
+    "generate_video_by_minimax_h3_jaaz",
+    description="Generate videos using MiniMax H3 with 2K output, 4-15 second duration, and text or image inputs.",
+    args_schema=GenerateVideoByMiniMaxH3InputSchema,
+)
+async def generate_video_by_minimax_h3_jaaz(
+    prompt: str,
+    config: RunnableConfig,
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    resolution: str = "2K",
+    duration: int = 5,
+    ratio: str = "16:9",
+    input_images: list[str] | None = None,
+    callback_url: str | None = None,
+) -> str:
+    processed_input_images = None
+    if input_images and len(input_images) > 0:
+        processed_input_images = []
+        for image_name in input_images:
+            processed_image = await process_input_image(image_name)
+            if not processed_image:
+                raise ValueError(
+                    f"Failed to process input image: {image_name}. Please check if the image exists and is valid."
+                )
+            processed_input_images.append(processed_image)
+
+    return await generate_video_with_provider(
+        prompt=prompt,
+        resolution=resolution,
+        duration=duration,
+        aspect_ratio=ratio,
+        model="MiniMax-H3",
+        tool_call_id=tool_call_id,
+        config=config,
+        input_images=processed_input_images,
+        callback_url=callback_url,
+    )
+
+
+__all__ = ["generate_video_by_minimax_h3_jaaz"]

--- a/server/tools/video_generation/video_generation_core.py
+++ b/server/tools/video_generation/video_generation_core.py
@@ -9,6 +9,7 @@ from models.config_model import ModelInfo
 from ..video_providers.video_base_provider import get_default_provider, VideoProviderBase
 # Import all providers to ensure automatic registration (don't delete these imports)
 from ..video_providers.volces_provider import VolcesVideoProvider  # type: ignore
+from ..video_providers.minimax_provider import MiniMaxVideoProvider  # type: ignore
 from .video_canvas_utils import (
     send_video_start_notification,
     send_video_error_notification,

--- a/server/tools/video_providers/minimax_provider.py
+++ b/server/tools/video_providers/minimax_provider.py
@@ -1,0 +1,393 @@
+import asyncio
+import traceback
+from typing import Any, Dict, List, Optional
+
+from services.config_service import config_service
+from utils.http_client import HttpClient
+
+from .video_base_provider import VideoProviderBase
+
+
+class MiniMaxVideoProvider(VideoProviderBase, provider_name="minimax"):
+    """MiniMax H3 video generation provider implementation"""
+
+    def __init__(self):
+        config = config_service.app_config.get("minimax", {})
+        self.api_key = str(config.get("api_key", ""))
+        self.base_url = str(config.get("url", "https://api.minimax.io")).rstrip("/")
+        self.model_name = str(config.get("model_name", "MiniMax-H3"))
+
+        if not self.api_key:
+            raise ValueError("MiniMax API key is not configured")
+        if not self.base_url:
+            raise ValueError("MiniMax URL is not configured")
+
+    def _build_api_url(self, suffix: str = "") -> str:
+        base_url = self.base_url.rstrip("/")
+        if base_url.endswith("/v2/video_generation"):
+            endpoint = base_url
+        elif base_url.endswith("/v2"):
+            endpoint = f"{base_url}/video_generation"
+        else:
+            endpoint = f"{base_url}/v2/video_generation"
+
+        return f"{endpoint}{suffix}"
+
+    def _build_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    @staticmethod
+    def _clean_values(values: Optional[List[str]]) -> List[str]:
+        return [value.strip() for value in values or [] if value and value.strip()]
+
+    def _build_content(
+        self,
+        prompt: str,
+        input_images: Optional[List[str]] = None,
+        reference_images: Optional[List[str]] = None,
+        reference_videos: Optional[List[str]] = None,
+        reference_audios: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        text = prompt.strip()
+        if not text:
+            raise ValueError("Prompt is required")
+        if len(text) > 7000:
+            raise ValueError("Prompt must be 7000 characters or fewer")
+
+        images = self._clean_values(input_images)
+        refs = self._clean_values(reference_images)
+        videos = self._clean_values(reference_videos)
+        audios = self._clean_values(reference_audios)
+
+        if audios and not (images or refs or videos):
+            raise ValueError("Reference audio requires a reference image or video")
+
+        if (images and (refs or videos or audios)) or (
+            len(images) == 2 and (refs or videos or audios)
+        ):
+            raise ValueError("Frame roles and reference roles are mutually exclusive")
+
+        content: List[Dict[str, Any]] = [{"type": "text", "text": text}]
+
+        if images and not (refs or videos or audios):
+            if len(images) == 1:
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": images[0]},
+                        "role": "first_frame",
+                    }
+                )
+            elif len(images) == 2:
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": images[0]},
+                        "role": "first_frame",
+                    }
+                )
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": images[1]},
+                        "role": "last_frame",
+                    }
+                )
+            else:
+                for image_url in images:
+                    content.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": image_url},
+                            "role": "reference_image",
+                        }
+                    )
+            return content
+
+        for image_url in images + refs:
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": image_url},
+                    "role": "reference_image",
+                }
+            )
+
+        for video_url in videos:
+            content.append(
+                {
+                    "type": "video_url",
+                    "video_url": {"url": video_url},
+                    "role": "reference_video",
+                }
+            )
+
+        for audio_url in audios:
+            content.append(
+                {
+                    "type": "audio_url",
+                    "audio_url": {"url": audio_url},
+                    "role": "reference_audio",
+                }
+            )
+
+        return content
+
+    def _validate_request(
+        self,
+        resolution: str,
+        duration: int,
+        ratio: str,
+        content: List[Dict[str, Any]],
+    ) -> None:
+        if resolution != "2K":
+            raise ValueError("MiniMax H3 only supports 2K resolution")
+        if not isinstance(duration, int) or duration < 4 or duration > 15:
+            raise ValueError("MiniMax H3 duration must be an integer between 4 and 15")
+        if len(content) == 1 and ratio == "adaptive":
+            raise ValueError("Text-to-video requests require a concrete ratio")
+
+    @staticmethod
+    def _extract_error_message(payload: Dict[str, Any], status: int) -> str:
+        for key in ("message", "error", "detail"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+            if isinstance(value, dict):
+                nested = value.get("message") or value.get("detail")
+                if isinstance(nested, str) and nested.strip():
+                    return nested
+        base_resp = payload.get("base_resp")
+        if isinstance(base_resp, dict):
+            message = base_resp.get("status_msg") or base_resp.get("message")
+            if isinstance(message, str) and message.strip():
+                return message
+        return f"HTTP {status}"
+
+    @staticmethod
+    def _extract_task(response: Dict[str, Any]) -> Dict[str, Any]:
+        task = response.get("task")
+        if isinstance(task, dict):
+            return task
+        return response
+
+    @staticmethod
+    def _normalize_status(status: Any) -> str:
+        return str(status or "").strip().lower()
+
+    @staticmethod
+    def _extract_video_url(task: Dict[str, Any]) -> Optional[str]:
+        content = task.get("content")
+        if isinstance(content, dict):
+            url = content.get("url")
+            if isinstance(url, str) and url.strip():
+                return url.strip()
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict):
+                    url = item.get("url")
+                    if isinstance(url, str) and url.strip():
+                        return url.strip()
+        return None
+
+    async def _request_json(
+        self,
+        session: Any,
+        method: str,
+        path: str,
+        headers: Dict[str, str],
+        payload: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        async with session.request(
+            method,
+            self._build_api_url(path),
+            headers=headers,
+            json=payload,
+            params=params,
+        ) as response:
+            try:
+                data = await response.json()
+            except Exception:
+                data = {"message": await response.text()}
+
+            if response.status >= 400:
+                if not isinstance(data, dict):
+                    raise Exception(f"HTTP {response.status}")
+                raise Exception(self._extract_error_message(data, response.status))
+
+            if not isinstance(data, dict):
+                raise Exception("MiniMax video API returned an invalid response")
+
+            return data
+
+    async def create_video_generation_task(
+        self,
+        content: List[Dict[str, Any]],
+        resolution: str,
+        duration: int,
+        ratio: str,
+        callback_url: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> str:
+        headers = self._build_headers()
+        payload: Dict[str, Any] = {
+            "model": model or self.model_name,
+            "content": content,
+            "resolution": resolution,
+            "duration": duration,
+            "ratio": ratio,
+        }
+        if callback_url:
+            payload["callback_url"] = callback_url
+
+        async with HttpClient.create_aiohttp() as session:
+            response = await self._request_json(
+                session,
+                "POST",
+                "",
+                headers,
+                payload=payload,
+            )
+
+        task_id = str(response.get("task_id", "")).strip()
+        if not task_id:
+            raise Exception("MiniMax video generation task creation failed")
+
+        return task_id
+
+    async def query_video_generation_task(self, task_id: str) -> Dict[str, Any]:
+        headers = self._build_headers()
+        async with HttpClient.create_aiohttp() as session:
+            return await self._request_json(
+                session,
+                "GET",
+                f"/{task_id}",
+                headers,
+            )
+
+    async def list_video_generation_tasks(
+        self,
+        page_num: int = 1,
+        page_size: int = 20,
+        filter_status: Optional[str] = None,
+        filter_task_ids: Optional[List[str]] = None,
+        filter_model: Optional[str] = None,
+        filter_task_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        headers = self._build_headers()
+        params: Dict[str, Any] = {
+            "page_num": page_num,
+            "page_size": page_size,
+        }
+        if filter_status:
+            params["filter.status"] = filter_status
+        if filter_task_ids:
+            params["filter.task_ids"] = filter_task_ids
+        if filter_model:
+            params["filter.model"] = filter_model
+        if filter_task_type:
+            params["filter.task_type"] = filter_task_type
+
+        async with HttpClient.create_aiohttp() as session:
+            return await self._request_json(
+                session,
+                "GET",
+                "",
+                headers,
+                params=params,
+            )
+
+    async def delete_video_generation_task(self, task_id: str) -> Dict[str, Any]:
+        headers = self._build_headers()
+        async with HttpClient.create_aiohttp() as session:
+            return await self._request_json(
+                session,
+                "DELETE",
+                f"/{task_id}",
+                headers,
+            )
+
+    async def _poll_for_task_completion(self, task_id: str) -> str:
+        headers = self._build_headers()
+        async with HttpClient.create_aiohttp() as session:
+            while True:
+                response = await self._request_json(
+                    session,
+                    "GET",
+                    f"/query/video_generation/{task_id}",
+                    headers,
+                )
+                task = self._extract_task(response)
+                status = self._normalize_status(task.get("status"))
+
+                if status in {"succeeded", "success", "completed", "done"}:
+                    video_url = self._extract_video_url(task)
+                    if video_url:
+                        return video_url
+                    raise Exception("No video URL found in successful response")
+
+                if status in {"failed", "cancelled", "canceled", "error", "expired"}:
+                    detail_error = task.get("error") or task.get("message")
+                    if not detail_error:
+                        detail_error = f"Task failed with status: {status}"
+                    raise Exception(f"MiniMax video generation failed: {detail_error}")
+
+                print(
+                    f"🎥 Polling MiniMax H3 generation {task_id}, current status: {status} ..."
+                )
+                await asyncio.sleep(5)
+
+    async def generate(
+        self,
+        prompt: str,
+        model: str,
+        resolution: str = "2K",
+        duration: int = 5,
+        aspect_ratio: str = "16:9",
+        input_images: Optional[List[str]] = None,
+        camera_fixed: bool = True,
+        **kwargs: Any,
+    ) -> str:
+        try:
+            selected_model = model or self.model_name
+            if selected_model != "MiniMax-H3":
+                raise ValueError("MiniMax video provider only supports MiniMax-H3")
+
+            reference_images = kwargs.pop("reference_images", None)
+            reference_videos = kwargs.pop("reference_videos", None)
+            reference_audios = kwargs.pop("reference_audios", None)
+            callback_url = kwargs.pop("callback_url", None)
+            ratio = str(kwargs.pop("ratio", aspect_ratio))
+
+            content = self._build_content(
+                prompt=prompt,
+                input_images=input_images,
+                reference_images=reference_images,
+                reference_videos=reference_videos,
+                reference_audios=reference_audios,
+            )
+            self._validate_request(resolution, duration, ratio, content)
+
+            task_id = await self.create_video_generation_task(
+                content=content,
+                resolution=resolution,
+                duration=duration,
+                ratio=ratio,
+                callback_url=callback_url,
+                model=selected_model,
+            )
+
+            video_url = await self._poll_for_task_completion(task_id)
+            print(f"🎥 MiniMax H3 video generation completed, video URL: {video_url}")
+            return video_url
+        except Exception as e:
+            print(f"🎥 Error generating video with MiniMax H3: {str(e)}")
+            traceback.print_exc()
+            raise e
+
+
+__all__ = ["MiniMaxVideoProvider"]

--- a/server/tools/video_providers/minimax_provider.py
+++ b/server/tools/video_providers/minimax_provider.py
@@ -22,16 +22,16 @@ class MiniMaxVideoProvider(VideoProviderBase, provider_name="minimax"):
         if not self.base_url:
             raise ValueError("MiniMax URL is not configured")
 
-    def _build_api_url(self, suffix: str = "") -> str:
+    def _build_api_url(self, path: str = "/video_generation") -> str:
         base_url = self.base_url.rstrip("/")
         if base_url.endswith("/v2/video_generation"):
-            endpoint = base_url
+            api_root = base_url.removesuffix("/video_generation")
         elif base_url.endswith("/v2"):
-            endpoint = f"{base_url}/video_generation"
+            api_root = base_url
         else:
-            endpoint = f"{base_url}/v2/video_generation"
+            api_root = f"{base_url}/v2"
 
-        return f"{endpoint}{suffix}"
+        return f"{api_root}/{path.lstrip('/')}"
 
     def _build_headers(self) -> Dict[str, str]:
         return {
@@ -248,7 +248,7 @@ class MiniMaxVideoProvider(VideoProviderBase, provider_name="minimax"):
             response = await self._request_json(
                 session,
                 "POST",
-                "",
+                "/video_generation",
                 headers,
                 payload=payload,
             )
@@ -265,7 +265,7 @@ class MiniMaxVideoProvider(VideoProviderBase, provider_name="minimax"):
             return await self._request_json(
                 session,
                 "GET",
-                f"/{task_id}",
+                f"/query/video_generation/{task_id}",
                 headers,
             )
 
@@ -296,7 +296,7 @@ class MiniMaxVideoProvider(VideoProviderBase, provider_name="minimax"):
             return await self._request_json(
                 session,
                 "GET",
-                "",
+                "/query/video_generation",
                 headers,
                 params=params,
             )
@@ -307,7 +307,7 @@ class MiniMaxVideoProvider(VideoProviderBase, provider_name="minimax"):
             return await self._request_json(
                 session,
                 "DELETE",
-                f"/{task_id}",
+                f"/video_generation/{task_id}",
                 headers,
             )
 


### PR DESCRIPTION
Reason: Add MiniMax H3 video generation wiring for the V2 create/query/list/delete flow.

Changes:
- Added a MiniMax H3 video provider with request validation, task creation, polling, listing, and deletion helpers.
- Added a dedicated MiniMax H3 tool entry and registered it in the video tool map.
- Added the provider to the default server config and covered the new content-role and validation paths with tests.

Checks:
- `python3 -m py_compile` on the touched server Python files.
- Direct Python assertions for MiniMax H3 endpoint, content-role, and validation helpers.
- Imported the shared tool registry and confirmed the new MiniMax H3 tool entry is present.
