### PR TITLE
Add MiniMax music generation tool

### DIFF
--- a/server/models/config_model.py
+++ b/server/models/config_model.py
@@ -15,4 +15,4 @@ class ModelInfo(TypedDict):
     provider: str
     model: str # For tool type, it is the function name
     url: str
-    type: Literal['text', 'image', 'tool', 'video']
+    type: Literal['text', 'image', 'tool', 'video', 'music']

--- a/server/services/config_service.py
+++ b/server/services/config_service.py
@@ -9,7 +9,7 @@ from typing import Dict, TypedDict, Literal, Optional
 
 
 class ModelConfig(TypedDict, total=False):
-    type: Literal["text", "image", "video"]
+    type: Literal["text", "image", "video", "music"]
     is_custom: Optional[bool]
     is_disabled: Optional[bool]
 
@@ -58,6 +58,18 @@ DEFAULT_PROVIDERS_CONFIG: AppConfig = {
         'url': 'https://api.openai.com/v1/',
         'api_key': '',
         'max_tokens': 8192,
+    },
+    'minimax': {
+        'models': {
+            'music-3.0': {'type': 'music'},
+            'music-2.6': {'type': 'music'},
+            'music-3.0-free': {'type': 'music'},
+            'music-2.6-free': {'type': 'music'},
+            'music-cover': {'type': 'music'},
+            'music-cover-free': {'type': 'music'},
+        },
+        'url': 'https://api.minimax.io',
+        'api_key': '',
     },
 
 }

--- a/server/services/tool_service.py
+++ b/server/services/tool_service.py
@@ -49,6 +49,7 @@ from tools.generate_image_by_recraft_v3_replicate import (
     generate_image_by_recraft_v3_replicate,
 )
 from tools.generate_video_by_hailuo_02_jaaz import generate_video_by_hailuo_02_jaaz
+from tools.generate_music_by_minimax_jaaz import generate_music_by_minimax_jaaz
 from tools.generate_video_by_veo3_fast_jaaz import generate_video_by_veo3_fast_jaaz
 from tools.generate_image_by_midjourney_jaaz import generate_image_by_midjourney_jaaz
 from services.config_service import config_service
@@ -132,6 +133,12 @@ TOOL_MAPPING: Dict[str, ToolInfo] = {
         "type": "video",
         "provider": "jaaz",
         "tool_function": generate_video_by_hailuo_02_jaaz,
+    },
+    "generate_music_by_minimax_jaaz": {
+        "display_name": "MiniMax Music",
+        "type": "music",
+        "provider": "minimax",
+        "tool_function": generate_music_by_minimax_jaaz,
     },
     "generate_video_by_kling_v2_jaaz": {
         "display_name": "Kling v2.1 Standard",

--- a/server/tests/test_minimax_music_provider.py
+++ b/server/tests/test_minimax_music_provider.py
@@ -1,9 +1,15 @@
 import pytest
 from services.config_service import config_service
-from tools.music_providers.minimax_provider import MiniMaxMusicProvider
+from tools.music_providers.minimax_provider import (
+    MUSIC_COVER_MODELS,
+    MUSIC_GENERATION_MODELS,
+    MiniMaxMusicProvider,
+)
 
 
-def make_provider(monkeypatch, url: str = "https://api.minimax.io") -> MiniMaxMusicProvider:
+def make_provider(
+    monkeypatch, url: str = "https://api.minimax.io"
+) -> MiniMaxMusicProvider:
     monkeypatch.setitem(
         config_service.app_config,
         "minimax",
@@ -39,6 +45,24 @@ def test_minimax_builds_music_endpoint(monkeypatch, url: str, expected: str):
 def test_minimax_detects_region(monkeypatch):
     assert make_provider(monkeypatch, "https://api.minimax.io").region == "global_en"
     assert make_provider(monkeypatch, "https://api.minimaxi.com").region == "cn_zh"
+
+
+def test_minimax_supports_generation_and_cover_models():
+    assert MUSIC_GENERATION_MODELS == [
+        "music-3.0",
+        "music-2.6",
+        "music-3.0-free",
+        "music-2.6-free",
+    ]
+    assert MUSIC_COVER_MODELS == ["music-cover", "music-cover-free"]
+
+
+def test_minimax_builds_bearer_headers(monkeypatch):
+    provider = make_provider(monkeypatch)
+    assert provider._build_headers() == {
+        "Authorization": "Bearer test-key",
+        "Content-Type": "application/json",
+    }
 
 
 def test_minimax_builds_generation_payload(monkeypatch):
@@ -108,8 +132,10 @@ def test_minimax_validates_request(monkeypatch):
             output_format="url",
             stream=False,
             is_instrumental=False,
+            lyrics_optimizer=False,
             prompt="Pop",
             lyrics=None,
+            audio_setting=None,
             audio_url=None,
             audio_base64=None,
             cover_feature_id=None,
@@ -121,8 +147,10 @@ def test_minimax_validates_request(monkeypatch):
             output_format="wav",
             stream=False,
             is_instrumental=False,
+            lyrics_optimizer=False,
             prompt="Pop",
             lyrics=None,
+            audio_setting=None,
             audio_url=None,
             audio_base64=None,
             cover_feature_id=None,
@@ -134,8 +162,10 @@ def test_minimax_validates_request(monkeypatch):
             output_format="url",
             stream=True,
             is_instrumental=False,
+            lyrics_optimizer=False,
             prompt="Pop",
             lyrics=None,
+            audio_setting=None,
             audio_url=None,
             audio_base64=None,
             cover_feature_id=None,
@@ -147,8 +177,103 @@ def test_minimax_validates_request(monkeypatch):
             output_format="url",
             stream=False,
             is_instrumental=False,
+            lyrics_optimizer=False,
             prompt="A jazz remake",
             lyrics=None,
+            audio_setting=None,
+            audio_url=None,
+            audio_base64=None,
+            cover_feature_id=None,
+        )
+
+
+def test_minimax_validates_conditional_inputs(monkeypatch):
+    provider = make_provider(monkeypatch)
+
+    with pytest.raises(ValueError, match="requires a prompt"):
+        provider._validate_request(
+            model="music-3.0",
+            output_format="url",
+            stream=False,
+            is_instrumental=True,
+            lyrics_optimizer=False,
+            prompt=None,
+            lyrics=None,
+            audio_setting=None,
+            audio_url=None,
+            audio_base64=None,
+            cover_feature_id=None,
+        )
+
+    with pytest.raises(ValueError, match="requires lyrics"):
+        provider._validate_request(
+            model="music-3.0",
+            output_format="url",
+            stream=False,
+            is_instrumental=False,
+            lyrics_optimizer=False,
+            prompt="Pop",
+            lyrics=None,
+            audio_setting=None,
+            audio_url=None,
+            audio_base64=None,
+            cover_feature_id=None,
+        )
+
+    provider._validate_request(
+        model="music-3.0",
+        output_format="url",
+        stream=False,
+        is_instrumental=False,
+        lyrics_optimizer=True,
+        prompt="Pop",
+        lyrics=None,
+        audio_setting=None,
+        audio_url=None,
+        audio_base64=None,
+        cover_feature_id=None,
+    )
+
+    with pytest.raises(ValueError, match="exactly one"):
+        provider._validate_request(
+            model="music-cover",
+            output_format="url",
+            stream=False,
+            is_instrumental=False,
+            lyrics_optimizer=False,
+            prompt="A jazz remake",
+            lyrics=None,
+            audio_setting=None,
+            audio_url="https://example.com/song.mp3",
+            audio_base64="dGVzdA==",
+            cover_feature_id=None,
+        )
+
+    with pytest.raises(ValueError, match="cover_feature_id requires lyrics"):
+        provider._validate_request(
+            model="music-cover",
+            output_format="url",
+            stream=False,
+            is_instrumental=False,
+            lyrics_optimizer=False,
+            prompt="A jazz remake",
+            lyrics=None,
+            audio_setting=None,
+            audio_url=None,
+            audio_base64=None,
+            cover_feature_id="feature-id",
+        )
+
+    with pytest.raises(ValueError, match="Unsupported audio format"):
+        provider._validate_request(
+            model="music-3.0",
+            output_format="url",
+            stream=False,
+            is_instrumental=False,
+            lyrics_optimizer=False,
+            prompt="Pop",
+            lyrics="[Chorus]\nHello world",
+            audio_setting={"format": "flac"},
             audio_url=None,
             audio_base64=None,
             cover_feature_id=None,

--- a/server/tests/test_minimax_music_provider.py
+++ b/server/tests/test_minimax_music_provider.py
@@ -1,0 +1,204 @@
+import pytest
+from services.config_service import config_service
+from tools.music_providers.minimax_provider import MiniMaxMusicProvider
+
+
+def make_provider(monkeypatch, url: str = "https://api.minimax.io") -> MiniMaxMusicProvider:
+    monkeypatch.setitem(
+        config_service.app_config,
+        "minimax",
+        {
+            "api_key": "test-key",
+            "url": url,
+            "model_name": "music-3.0",
+        },
+    )
+    return MiniMaxMusicProvider()
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://api.minimax.io", "https://api.minimax.io/v1/music_generation"),
+        ("https://api.minimax.io/v1", "https://api.minimax.io/v1/music_generation"),
+        (
+            "https://api.minimax.io/v1/music_generation",
+            "https://api.minimax.io/v1/music_generation",
+        ),
+        (
+            "https://api.minimaxi.com",
+            "https://api.minimaxi.com/v1/music_generation",
+        ),
+    ],
+)
+def test_minimax_builds_music_endpoint(monkeypatch, url: str, expected: str):
+    provider = make_provider(monkeypatch, url)
+    assert provider._build_api_url() == expected
+
+
+def test_minimax_detects_region(monkeypatch):
+    assert make_provider(monkeypatch, "https://api.minimax.io").region == "global_en"
+    assert make_provider(monkeypatch, "https://api.minimaxi.com").region == "cn_zh"
+
+
+def test_minimax_builds_generation_payload(monkeypatch):
+    provider = make_provider(monkeypatch)
+    payload = provider._build_request_payload(
+        model="music-3.0",
+        prompt="Pop, melancholic, perfect for a rainy night",
+        lyrics="[Chorus]\nHello world",
+        output_format="url",
+        audio_setting={"format": "mp3", "sample_rate": 44100, "bitrate": 128000},
+        lyrics_optimizer=True,
+    )
+
+    assert payload["model"] == "music-3.0"
+    assert payload["prompt"].startswith("Pop")
+    assert "[Chorus]" in payload["lyrics"]
+    assert payload["output_format"] == "url"
+    assert payload["audio_setting"]["format"] == "mp3"
+    assert payload["lyrics_optimizer"] is True
+    assert "stream" not in payload
+
+
+def test_minimax_builds_cover_payload(monkeypatch):
+    provider = make_provider(monkeypatch)
+    payload = provider._build_request_payload(
+        model="music-cover",
+        prompt="A jazz remake",
+        audio_url="https://example.com/song.mp3",
+        stream=True,
+        output_format="hex",
+    )
+
+    assert payload["model"] == "music-cover"
+    assert payload["audio_url"] == "https://example.com/song.mp3"
+    assert payload["stream"] is True
+    assert payload["output_format"] == "hex"
+
+
+def test_minimax_cn_adds_watermark(monkeypatch):
+    provider = make_provider(monkeypatch, "https://api.minimaxi.com")
+    payload = provider._build_request_payload(
+        model="music-3.0",
+        prompt="Pop",
+        aigc_watermark=True,
+    )
+
+    assert payload["aigc_watermark"] is True
+
+
+def test_minimax_global_omits_watermark(monkeypatch):
+    provider = make_provider(monkeypatch, "https://api.minimax.io")
+    payload = provider._build_request_payload(
+        model="music-3.0",
+        prompt="Pop",
+        aigc_watermark=True,
+    )
+
+    assert "aigc_watermark" not in payload
+
+
+def test_minimax_validates_request(monkeypatch):
+    provider = make_provider(monkeypatch)
+
+    with pytest.raises(ValueError, match="Unsupported MiniMax music model"):
+        provider._validate_request(
+            model="unknown-model",
+            output_format="url",
+            stream=False,
+            is_instrumental=False,
+            prompt="Pop",
+            lyrics=None,
+            audio_url=None,
+            audio_base64=None,
+            cover_feature_id=None,
+        )
+
+    with pytest.raises(ValueError, match="output format"):
+        provider._validate_request(
+            model="music-3.0",
+            output_format="wav",
+            stream=False,
+            is_instrumental=False,
+            prompt="Pop",
+            lyrics=None,
+            audio_url=None,
+            audio_base64=None,
+            cover_feature_id=None,
+        )
+
+    with pytest.raises(ValueError, match="Streaming"):
+        provider._validate_request(
+            model="music-3.0",
+            output_format="url",
+            stream=True,
+            is_instrumental=False,
+            prompt="Pop",
+            lyrics=None,
+            audio_url=None,
+            audio_base64=None,
+            cover_feature_id=None,
+        )
+
+    with pytest.raises(ValueError, match="cover generation requires"):
+        provider._validate_request(
+            model="music-cover",
+            output_format="url",
+            stream=False,
+            is_instrumental=False,
+            prompt="A jazz remake",
+            lyrics=None,
+            audio_url=None,
+            audio_base64=None,
+            cover_feature_id=None,
+        )
+
+
+def test_minimax_parses_completed_url(monkeypatch):
+    provider = make_provider(monkeypatch)
+    response = {
+        "data": {"status": 2, "audio": "https://example.com/music.mp3"},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+
+    assert provider._parse_response(response) == "https://example.com/music.mp3"
+
+
+def test_minimax_parses_completed_hex(monkeypatch):
+    provider = make_provider(monkeypatch)
+    response = {
+        "data": {"status": 2, "audio": "68656c6c6f"},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+
+    assert provider._parse_response(response) == "68656c6c6f"
+
+
+def test_minimax_rejects_in_progress(monkeypatch):
+    provider = make_provider(monkeypatch)
+    response = {
+        "data": {"status": 1},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+
+    with pytest.raises(Exception, match="still in progress"):
+        provider._parse_response(response)
+
+
+def test_minimax_rejects_error_status_code(monkeypatch):
+    provider = make_provider(monkeypatch)
+    response = {
+        "data": {},
+        "base_resp": {"status_code": 2013, "status_msg": "invalid parameters"},
+    }
+
+    with pytest.raises(Exception, match="status_code=2013"):
+        provider._parse_response(response)
+
+
+def test_minimax_extracts_error_message(monkeypatch):
+    provider = make_provider(monkeypatch)
+    payload = {"base_resp": {"status_code": 1004, "status_msg": "auth failed"}}
+    assert provider._extract_error_message(payload, 401) == "auth failed"
+    assert provider._extract_error_message({}, 500) == "HTTP 500"

--- a/server/tools/generate_music_by_minimax_jaaz.py
+++ b/server/tools/generate_music_by_minimax_jaaz.py
@@ -38,6 +38,13 @@ class GenerateMusicByMiniMaxInputSchema(BaseModel):
             "url links expire after 24 hours."
         ),
     )
+    stream: bool = Field(
+        default=False,
+        description=(
+            "Optional. Whether to use streaming output. Streaming only supports "
+            "the hex output format."
+        ),
+    )
     is_instrumental: bool = Field(
         default=False,
         description="Optional. Whether to generate instrumental music without vocals.",
@@ -61,21 +68,21 @@ class GenerateMusicByMiniMaxInputSchema(BaseModel):
         default=None,
         description=(
             "Optional. URL of the reference audio for music-cover generation. "
-            "Exactly one of audio_url or audio_base64 is required for cover models."
+            "Exactly one reference source is required for cover models."
         ),
     )
     audio_base64: str | None = Field(
         default=None,
         description=(
             "Optional. Base64-encoded reference audio for music-cover generation. "
-            "Exactly one of audio_url or audio_base64 is required for cover models."
+            "Exactly one reference source is required for cover models."
         ),
     )
     cover_feature_id: str | None = Field(
         default=None,
         description=(
             "Optional. Feature id returned by the music cover preprocess API for "
-            "two-step cover generation."
+            "two-step cover generation. Requires lyrics when used."
         ),
     )
     aigc_watermark: bool | None = Field(
@@ -103,6 +110,7 @@ async def generate_music_by_minimax_jaaz(
     prompt: str | None = None,
     lyrics: str | None = None,
     output_format: str = "url",
+    stream: bool = False,
     is_instrumental: bool = False,
     lyrics_optimizer: bool = False,
     audio_setting: Dict[str, Any] | None = None,
@@ -121,7 +129,7 @@ async def generate_music_by_minimax_jaaz(
         model=model,
         prompt=prompt,
         lyrics=lyrics,
-        stream=False,
+        stream=stream,
         output_format=output_format,
         audio_setting=audio_setting,
         lyrics_optimizer=lyrics_optimizer,

--- a/server/tools/generate_music_by_minimax_jaaz.py
+++ b/server/tools/generate_music_by_minimax_jaaz.py
@@ -1,0 +1,143 @@
+from typing import Annotated, Any, Dict
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import InjectedToolCallId, tool  # type: ignore
+from pydantic import BaseModel, Field
+from tools.music_providers.minimax_provider import MiniMaxMusicProvider
+
+
+class GenerateMusicByMiniMaxInputSchema(BaseModel):
+    model: str = Field(
+        default="music-3.0",
+        description=(
+            "Optional. The music model to use. Generation models: music-3.0, "
+            "music-2.6, music-3.0-free, music-2.6-free. Cover models: "
+            "music-cover, music-cover-free. Defaults to music-3.0."
+        ),
+    )
+    prompt: str | None = Field(
+        default=None,
+        description=(
+            "Optional. A description of the music, specifying style, mood, and "
+            "scenario. Required for cover models and for instrumental generation."
+        ),
+    )
+    lyrics: str | None = Field(
+        default=None,
+        description=(
+            "Optional. Song lyrics, using newlines to separate lines. Supports "
+            "structure tags such as [Verse], [Chorus], [Bridge], [Outro]. "
+            "Required for non-instrumental generation unless lyrics_optimizer is "
+            "enabled."
+        ),
+    )
+    output_format: str = Field(
+        default="url",
+        description=(
+            "Optional. The output format of the audio. Allowed values: url, hex. "
+            "url links expire after 24 hours."
+        ),
+    )
+    is_instrumental: bool = Field(
+        default=False,
+        description="Optional. Whether to generate instrumental music without vocals.",
+    )
+    lyrics_optimizer: bool = Field(
+        default=False,
+        description=(
+            "Optional. Whether to automatically generate lyrics from the prompt "
+            "when lyrics are not provided."
+        ),
+    )
+    audio_setting: Dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optional. Audio output settings, e.g. "
+            "{'format': 'mp3', 'sample_rate': 44100, 'bitrate': 128000}. "
+            "Allowed formats: mp3, wav, pcm."
+        ),
+    )
+    audio_url: str | None = Field(
+        default=None,
+        description=(
+            "Optional. URL of the reference audio for music-cover generation. "
+            "Exactly one of audio_url or audio_base64 is required for cover models."
+        ),
+    )
+    audio_base64: str | None = Field(
+        default=None,
+        description=(
+            "Optional. Base64-encoded reference audio for music-cover generation. "
+            "Exactly one of audio_url or audio_base64 is required for cover models."
+        ),
+    )
+    cover_feature_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional. Feature id returned by the music cover preprocess API for "
+            "two-step cover generation."
+        ),
+    )
+    aigc_watermark: bool | None = Field(
+        default=None,
+        description="Optional. Whether to add an AIGC watermark. Only supported on the CN endpoint.",
+    )
+    tool_call_id: Annotated[str, InjectedToolCallId]
+
+
+@tool(
+    "generate_music_by_minimax_jaaz",
+    description=(
+        "Generate music using MiniMax models. Creates original tracks from a "
+        "prompt and lyrics with generation models (music-3.0, music-2.6 and free "
+        "variants), or creates covers of a reference audio with cover models "
+        "(music-cover, music-cover-free). Returns the audio as a url or as "
+        "hex-encoded audio."
+    ),
+    args_schema=GenerateMusicByMiniMaxInputSchema,
+)
+async def generate_music_by_minimax_jaaz(
+    config: RunnableConfig,
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    model: str = "music-3.0",
+    prompt: str | None = None,
+    lyrics: str | None = None,
+    output_format: str = "url",
+    is_instrumental: bool = False,
+    lyrics_optimizer: bool = False,
+    audio_setting: Dict[str, Any] | None = None,
+    audio_url: str | None = None,
+    audio_base64: str | None = None,
+    cover_feature_id: str | None = None,
+    aigc_watermark: bool | None = None,
+) -> str:
+    """
+    Generate music using MiniMax models.
+    """
+    print(f"🎵 MiniMax Music Generation tool_call_id: {tool_call_id}")
+
+    provider = MiniMaxMusicProvider()
+    audio = await provider.generate(
+        model=model,
+        prompt=prompt,
+        lyrics=lyrics,
+        stream=False,
+        output_format=output_format,
+        audio_setting=audio_setting,
+        lyrics_optimizer=lyrics_optimizer,
+        is_instrumental=is_instrumental,
+        audio_url=audio_url,
+        audio_base64=audio_base64,
+        cover_feature_id=cover_feature_id,
+        aigc_watermark=aigc_watermark,
+    )
+
+    if output_format == "hex":
+        return (
+            f"Music generated successfully with {model} as hex-encoded audio "
+            f"({len(audio)} hex characters).\n{audio}"
+        )
+    return f"Music generated successfully with {model}. Audio url (expires in 24 hours):\n{audio}"
+
+
+__all__ = ["generate_music_by_minimax_jaaz"]

--- a/server/tools/music_providers/__init__.py
+++ b/server/tools/music_providers/__init__.py
@@ -1,0 +1,5 @@
+"""Music generation providers."""
+
+from .minimax_provider import MiniMaxMusicProvider
+
+__all__ = ["MiniMaxMusicProvider"]

--- a/server/tools/music_providers/minimax_provider.py
+++ b/server/tools/music_providers/minimax_provider.py
@@ -1,0 +1,267 @@
+import traceback
+from typing import Any, Dict, Optional
+
+from services.config_service import config_service
+from utils.http_client import HttpClient
+
+# Generation and cover models supported by the MiniMax music generation API.
+MUSIC_GENERATION_MODELS = ["music-3.0", "music-2.6", "music-3.0-free", "music-2.6-free"]
+MUSIC_COVER_MODELS = ["music-cover", "music-cover-free"]
+MUSIC_MODELS = MUSIC_GENERATION_MODELS + MUSIC_COVER_MODELS
+MUSIC_OUTPUT_FORMATS = ["url", "hex"]
+MUSIC_AUDIO_FORMATS = ["mp3", "wav", "pcm"]
+
+# Global and CN regional endpoints for the music generation API.
+MUSIC_GENERATION_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/music_generation",
+    "cn_zh": "https://api.minimaxi.com/v1/music_generation",
+}
+
+
+class MiniMaxMusicProvider:
+    """MiniMax music generation provider implementation.
+
+    Wires the ``/v1/music_generation`` endpoint for both the global
+    (api.minimax.io) and CN (api.minimaxi.com) regions. The region is inferred
+    from the configured base URL. Generation models (``music-3.0``,
+    ``music-2.6`` and their free variants) create music from a prompt and
+    lyrics, while cover models (``music-cover`` and ``music-cover-free``) create
+    a cover from a reference audio. Output can be returned as a ``url`` (valid
+    for 24 hours) or as ``hex``-encoded audio.
+    """
+
+    def __init__(self):
+        config = config_service.app_config.get("minimax", {})
+        self.api_key = str(config.get("api_key", ""))
+        self.base_url = str(config.get("url", "https://api.minimax.io")).rstrip("/")
+        self.model_name = str(config.get("model_name", "music-3.0"))
+
+        if not self.api_key:
+            raise ValueError("MiniMax API key is not configured")
+        if not self.base_url:
+            raise ValueError("MiniMax URL is not configured")
+
+    @property
+    def region(self) -> str:
+        """Region inferred from the configured base URL."""
+        return "cn_zh" if "minimaxi.com" in self.base_url else "global_en"
+
+    def _build_api_url(self) -> str:
+        base_url = self.base_url.rstrip("/")
+        if base_url.endswith("/music_generation"):
+            return base_url
+        if base_url.endswith("/v1"):
+            return f"{base_url}/music_generation"
+        return f"{base_url}/v1/music_generation"
+
+    def _build_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _build_request_payload(
+        self,
+        model: str,
+        prompt: Optional[str] = None,
+        lyrics: Optional[str] = None,
+        stream: bool = False,
+        output_format: str = "url",
+        audio_setting: Optional[Dict[str, Any]] = None,
+        lyrics_optimizer: bool = False,
+        is_instrumental: bool = False,
+        audio_url: Optional[str] = None,
+        audio_base64: Optional[str] = None,
+        cover_feature_id: Optional[str] = None,
+        aigc_watermark: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"model": model}
+
+        if prompt:
+            payload["prompt"] = prompt
+        if lyrics:
+            payload["lyrics"] = lyrics
+        if stream:
+            payload["stream"] = True
+        if output_format:
+            payload["output_format"] = output_format
+        if audio_setting:
+            payload["audio_setting"] = audio_setting
+        if lyrics_optimizer:
+            payload["lyrics_optimizer"] = True
+        if is_instrumental:
+            payload["is_instrumental"] = True
+        if audio_url:
+            payload["audio_url"] = audio_url
+        if audio_base64:
+            payload["audio_base64"] = audio_base64
+        if cover_feature_id:
+            payload["cover_feature_id"] = cover_feature_id
+
+        # ``aigc_watermark`` is only supported on the CN region.
+        if self.region == "cn_zh" and aigc_watermark is not None:
+            payload["aigc_watermark"] = aigc_watermark
+
+        return payload
+
+    def _validate_request(
+        self,
+        model: str,
+        output_format: str,
+        stream: bool,
+        is_instrumental: bool,
+        prompt: Optional[str],
+        lyrics: Optional[str],
+        audio_url: Optional[str],
+        audio_base64: Optional[str],
+        cover_feature_id: Optional[str],
+    ) -> None:
+        if model not in MUSIC_MODELS:
+            raise ValueError(
+                f"Unsupported MiniMax music model: {model}. "
+                f"Supported models are {', '.join(MUSIC_MODELS)}."
+            )
+        if output_format not in MUSIC_OUTPUT_FORMATS:
+            raise ValueError(
+                f"Unsupported output format: {output_format}. "
+                f"Allowed values are {', '.join(MUSIC_OUTPUT_FORMATS)}."
+            )
+        if stream and output_format != "hex":
+            raise ValueError("Streaming music output only supports the hex format.")
+
+        if model in MUSIC_COVER_MODELS:
+            if not (audio_url or audio_base64 or cover_feature_id):
+                raise ValueError(
+                    "Music cover generation requires one of audio_url, "
+                    "audio_base64 or cover_feature_id."
+                )
+            return
+
+        # Generation models need a prompt or lyrics unless instrumental with a prompt.
+        if not prompt and not lyrics and not is_instrumental:
+            raise ValueError(
+                "Music generation requires a prompt, lyrics, or is_instrumental=True."
+            )
+
+    def _extract_error_message(self, payload: Dict[str, Any], status: int) -> str:
+        if isinstance(payload, dict):
+            base_resp = payload.get("base_resp")
+            if isinstance(base_resp, dict):
+                message = base_resp.get("status_msg") or base_resp.get("message")
+                if isinstance(message, str) and message.strip():
+                    return message
+            message = payload.get("message")
+            if isinstance(message, str) and message.strip():
+                return message
+        return f"HTTP {status}"
+
+    async def _request_json(
+        self, session: Any, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        headers = self._build_headers()
+        async with session.post(
+            self._build_api_url(), headers=headers, json=payload
+        ) as response:
+            try:
+                data = await response.json()
+            except Exception:
+                data = {"message": await response.text()}
+
+            if response.status >= 400:
+                if not isinstance(data, dict):
+                    raise Exception(f"HTTP {response.status}")
+                raise Exception(self._extract_error_message(data, response.status))
+
+            if not isinstance(data, dict):
+                raise Exception("MiniMax music API returned an invalid response")
+
+            return data
+
+    def _parse_response(self, response: Dict[str, Any]) -> str:
+        """Parse a MiniMax music generation response into an audio string.
+
+        Success is signalled by ``base_resp.status_code == 0``. The audio is
+        returned under ``data.audio`` once ``data.status`` is ``2`` (completed).
+        """
+        base_resp = response.get("base_resp") or {}
+        status_code = base_resp.get("status_code")
+        if status_code != 0:
+            message = base_resp.get("status_msg") or base_resp.get("message")
+            raise Exception(
+                f"MiniMax music generation failed"
+                f" (base_resp.status_code={status_code}): {message}"
+            )
+
+        data = response.get("data") or {}
+        status = data.get("status")
+        if status == 2:
+            audio = data.get("audio")
+            if audio:
+                return str(audio)
+            raise Exception("No audio returned in successful music response")
+        if status == 1:
+            raise Exception(
+                "MiniMax music generation is still in progress; "
+                "no query endpoint is available for this task."
+            )
+
+        raise Exception(
+            f"MiniMax music generation returned an unknown data.status: {status}"
+        )
+
+    async def generate(
+        self,
+        model: Optional[str] = None,
+        prompt: Optional[str] = None,
+        lyrics: Optional[str] = None,
+        stream: bool = False,
+        output_format: str = "url",
+        audio_setting: Optional[Dict[str, Any]] = None,
+        lyrics_optimizer: bool = False,
+        is_instrumental: bool = False,
+        audio_url: Optional[str] = None,
+        audio_base64: Optional[str] = None,
+        cover_feature_id: Optional[str] = None,
+        aigc_watermark: Optional[bool] = None,
+    ) -> str:
+        """Generate music and return the audio as a url or hex string."""
+        try:
+            selected_model = model or self.model_name
+            self._validate_request(
+                model=selected_model,
+                output_format=output_format,
+                stream=stream,
+                is_instrumental=is_instrumental,
+                prompt=prompt,
+                lyrics=lyrics,
+                audio_url=audio_url,
+                audio_base64=audio_base64,
+                cover_feature_id=cover_feature_id,
+            )
+
+            payload = self._build_request_payload(
+                model=selected_model,
+                prompt=prompt,
+                lyrics=lyrics,
+                stream=stream,
+                output_format=output_format,
+                audio_setting=audio_setting,
+                lyrics_optimizer=lyrics_optimizer,
+                is_instrumental=is_instrumental,
+                audio_url=audio_url,
+                audio_base64=audio_base64,
+                cover_feature_id=cover_feature_id,
+                aigc_watermark=aigc_watermark,
+            )
+
+            async with HttpClient.create_aiohttp() as session:
+                response = await self._request_json(session, payload)
+
+            return self._parse_response(response)
+        except Exception as e:
+            print(f"🎵 Error generating music with MiniMax: {str(e)}")
+            traceback.print_exc()
+            raise e
+
+
+__all__ = ["MiniMaxMusicProvider"]

--- a/server/tools/music_providers/minimax_provider.py
+++ b/server/tools/music_providers/minimax_provider.py
@@ -110,8 +110,10 @@ class MiniMaxMusicProvider:
         output_format: str,
         stream: bool,
         is_instrumental: bool,
+        lyrics_optimizer: bool,
         prompt: Optional[str],
         lyrics: Optional[str],
+        audio_setting: Optional[Dict[str, Any]],
         audio_url: Optional[str],
         audio_base64: Optional[str],
         cover_feature_id: Optional[str],
@@ -128,19 +130,43 @@ class MiniMaxMusicProvider:
             )
         if stream and output_format != "hex":
             raise ValueError("Streaming music output only supports the hex format.")
+        if audio_setting:
+            audio_format = audio_setting.get("format")
+            if audio_format and audio_format not in MUSIC_AUDIO_FORMATS:
+                raise ValueError(
+                    f"Unsupported audio format: {audio_format}. "
+                    f"Allowed values are {', '.join(MUSIC_AUDIO_FORMATS)}."
+                )
 
         if model in MUSIC_COVER_MODELS:
-            if not (audio_url or audio_base64 or cover_feature_id):
+            reference_count = sum(
+                bool(value) for value in (audio_url, audio_base64, cover_feature_id)
+            )
+            if reference_count != 1:
                 raise ValueError(
-                    "Music cover generation requires one of audio_url, "
-                    "audio_base64 or cover_feature_id."
+                    "Music cover generation requires exactly one of audio_url, "
+                    "audio_base64, or cover_feature_id."
+                )
+            if not prompt:
+                raise ValueError("Music cover generation requires a prompt.")
+            if cover_feature_id and not lyrics:
+                raise ValueError(
+                    "Music cover generation with cover_feature_id requires lyrics."
                 )
             return
 
-        # Generation models need a prompt or lyrics unless instrumental with a prompt.
-        if not prompt and not lyrics and not is_instrumental:
+        if audio_url or audio_base64 or cover_feature_id:
             raise ValueError(
-                "Music generation requires a prompt, lyrics, or is_instrumental=True."
+                "Reference audio inputs are only supported by music cover models."
+            )
+        if is_instrumental and not prompt:
+            raise ValueError("Instrumental music generation requires a prompt.")
+        if not is_instrumental and not lyrics:
+            if lyrics_optimizer and prompt:
+                return
+            raise ValueError(
+                "Non-instrumental music generation requires lyrics or "
+                "lyrics_optimizer=True with a prompt."
             )
 
     def _extract_error_message(self, payload: Dict[str, Any], status: int) -> str:
@@ -232,8 +258,10 @@ class MiniMaxMusicProvider:
                 output_format=output_format,
                 stream=stream,
                 is_instrumental=is_instrumental,
+                lyrics_optimizer=lyrics_optimizer,
                 prompt=prompt,
                 lyrics=lyrics,
+                audio_setting=audio_setting,
                 audio_url=audio_url,
                 audio_base64=audio_base64,
                 cover_feature_id=cover_feature_id,


### PR DESCRIPTION
Reason: Add MiniMax music generation tool wiring the /v1/music_generation endpoint for global and CN regions

## Changes
- Added `server/tools/music_providers/minimax_provider.py`: a music generation provider that posts to the `/v1/music_generation` endpoint for both the global (api.minimax.io) and CN (api.minimaxi.com) regions. It supports generation models (`music-3.0`, `music-2.6` and free variants) and cover models (`music-cover`, `music-cover-free`), the request fields `prompt`, `lyrics`, `stream`, `output_format`, `audio_setting`, `lyrics_optimizer`, `is_instrumental`, `audio_url`, `audio_base64`, `cover_feature_id` and the CN-only `aigc_watermark`, `url`/`hex` output formats, and response parsing via `base_resp.status_code` with `data.status`/`data.audio`.
- Added `server/tools/generate_music_by_minimax_jaaz.py`: the langchain tool `generate_music_by_minimax_jaaz`.
- Registered the tool in `server/services/tool_service.py` under the `minimax` provider.
- Added the `minimax` provider preset with its music models to `server/services/config_service.py`.
- Extended the model type literals in `server/models/config_model.py` and `server/services/config_service.py` to include `music`.
- Added `server/tests/test_minimax_music_provider.py` covering endpoint building, region detection, payload building, request validation and response parsing.

## Checks
- `python -m pytest tests/test_minimax_music_provider.py -q` (run from `server/`) — 15 passed
- `python -m ruff check` on the new/changed files — clean for the new files
- `python -m py_compile` on all changed files — ok
