### PR TITLE
Add MiniMax image generation provider

### DIFF
--- a/server/services/config_service.py
+++ b/server/services/config_service.py
@@ -59,6 +59,14 @@ DEFAULT_PROVIDERS_CONFIG: AppConfig = {
         'api_key': '',
         'max_tokens': 8192,
     },
+    'minimax': {
+        'models': {
+            'image-01': {'type': 'image'},
+            'image-01-live': {'type': 'image'},
+        },
+        'url': 'https://api.minimax.io/v1/image_generation',
+        'api_key': '',
+    },
 
 }
 

--- a/server/tools/image_providers/minimax_provider.py
+++ b/server/tools/image_providers/minimax_provider.py
@@ -1,0 +1,62 @@
+import os
+from typing import Any, Optional
+
+from services.config_service import FILES_DIR, config_service
+from utils.http_client import HttpClient
+
+from .image_base_provider import ImageProviderBase
+from ..utils.image_utils import generate_image_id, get_image_info_and_save
+
+
+class MiniMaxImageProvider(ImageProviderBase):
+    """MiniMax image generation provider implementation."""
+
+    async def generate(
+        self,
+        prompt: str,
+        model: str,
+        aspect_ratio: str = "1:1",
+        input_images: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> tuple[str, int, int, str]:
+        config = config_service.app_config.get("minimax", {})
+        api_key = str(config.get("api_key", ""))
+        api_url = str(config.get("url", ""))
+
+        if not api_key:
+            raise ValueError("MiniMax API key is not configured")
+        if not api_url:
+            raise ValueError("MiniMax API URL is not configured")
+        if input_images:
+            raise ValueError("MiniMax text-to-image generation does not accept input images")
+
+        payload = {
+            "model": model.replace("minimax/", ""),
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "response_format": "url",
+            "n": kwargs.get("num_images", 1),
+            "prompt_optimizer": kwargs.get("prompt_optimizer", True),
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with HttpClient.create_aiohttp() as session:
+            async with session.post(api_url, json=payload, headers=headers) as response:
+                response_json = await response.json()
+
+        base_status = response_json.get("base_resp", {}).get("status_code")
+        image_urls = response_json.get("data", {}).get("image_urls", [])
+        if response.status != 200 or base_status not in (None, 0) or not image_urls:
+            raise RuntimeError(f"MiniMax image generation failed: {response_json}")
+
+        image_id = generate_image_id()
+        mime_type, width, height, extension = await get_image_info_and_save(
+            image_urls[0], os.path.join(FILES_DIR, image_id)
+        )
+        if mime_type is None:
+            raise RuntimeError("Failed to determine generated image MIME type")
+
+        return mime_type, width, height, f"{image_id}.{extension}"

--- a/server/tools/utils/image_generation_core.py
+++ b/server/tools/utils/image_generation_core.py
@@ -10,6 +10,7 @@ from ..image_providers.image_base_provider import ImageProviderBase
 
 # 导入所有提供商以确保自动注册 (不要删除这些导入)
 from ..image_providers.jaaz_provider import JaazImageProvider
+from ..image_providers.minimax_provider import MiniMaxImageProvider
 from ..image_providers.openai_provider import OpenAIImageProvider
 from ..image_providers.replicate_provider import ReplicateImageProvider
 from ..image_providers.volces_provider import VolcesProvider
@@ -23,6 +24,7 @@ import time
 
 IMAGE_PROVIDERS: dict[str, ImageProviderBase] = {
     "jaaz": JaazImageProvider(),
+    "minimax": MiniMaxImageProvider(),
     "openai": OpenAIImageProvider(),
     "replicate": ReplicateImageProvider(),
     "volces": VolcesProvider(),


### PR DESCRIPTION
Reason: Add MiniMax text-to-image generation through Jaaz's provider registry.

This adds a MiniMax image provider for the image-01 and image-01-live models, registers it with the image generation core, and provides the global image generation endpoint as the configurable default. The existing provider URL setting can also be changed to the China endpoint.

Checks:
- `python3 -m compileall -q server/tools/image_providers/minimax_provider.py server/tools/utils/image_generation_core.py server/services/config_service.py`
- `git diff --check`
