### PR TITLE
Complete MiniMax image-to-image references

### DIFF
--- a/server/services/config_service.py
+++ b/server/services/config_service.py
@@ -59,6 +59,14 @@ DEFAULT_PROVIDERS_CONFIG: AppConfig = {
         'api_key': '',
         'max_tokens': 8192,
     },
+    'minimax': {
+        'models': {
+            'image-01': {'type': 'image'},
+            'image-01-live': {'type': 'image'},
+        },
+        'url': 'https://api.minimax.io/v1/image_generation',
+        'api_key': '',
+    },
 
 }
 

--- a/server/services/tool_service.py
+++ b/server/services/tool_service.py
@@ -51,6 +51,7 @@ from tools.generate_image_by_recraft_v3_replicate import (
 from tools.generate_video_by_hailuo_02_jaaz import generate_video_by_hailuo_02_jaaz
 from tools.generate_video_by_veo3_fast_jaaz import generate_video_by_veo3_fast_jaaz
 from tools.generate_image_by_midjourney_jaaz import generate_image_by_midjourney_jaaz
+from tools.generate_image_by_minimax import generate_image_by_minimax
 from services.config_service import config_service
 from services.db_service import db_service
 
@@ -102,6 +103,12 @@ TOOL_MAPPING: Dict[str, ToolInfo] = {
         "type": "image",
         "provider": "jaaz",
         "tool_function": generate_image_by_midjourney_jaaz,
+    },
+    "generate_image_by_minimax": {
+        "display_name": "MiniMax Image",
+        "type": "image",
+        "provider": "minimax",
+        "tool_function": generate_image_by_minimax,
     },
     "generate_image_by_doubao_seedream_3_jaaz": {
         "display_name": "Doubao Seedream 3",

--- a/server/tools/generate_image_by_minimax.py
+++ b/server/tools/generate_image_by_minimax.py
@@ -1,0 +1,53 @@
+from typing import Annotated
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import InjectedToolCallId, tool  # type: ignore
+from pydantic import BaseModel, Field
+from tools.utils.image_generation_core import generate_image_with_provider
+
+
+class GenerateImageByMiniMaxInputSchema(BaseModel):
+    prompt: str = Field(
+        description="Required. The prompt for image generation or image editing."
+    )
+    aspect_ratio: str = Field(
+        default="1:1",
+        description="Optional. Supported ratios include 1:1, 16:9, 4:3, 3:2, 2:3, 3:4, 9:16, and 21:9.",
+    )
+    model: str = Field(
+        default="image-01",
+        description="Optional. MiniMax image model, either image-01 or image-01-live.",
+    )
+    input_images: list[str] | None = Field(
+        default=None,
+        description="Optional. Reference image IDs for image-to-image generation.",
+    )
+    tool_call_id: Annotated[str, InjectedToolCallId]
+
+
+@tool(
+    "generate_image_by_minimax",
+    description="Generate or edit an image with MiniMax using a text prompt and optional reference image.",
+    args_schema=GenerateImageByMiniMaxInputSchema,
+)
+async def generate_image_by_minimax(
+    prompt: str,
+    aspect_ratio: str,
+    config: RunnableConfig,
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    model: str = "image-01",
+    input_images: list[str] | None = None,
+) -> str:
+    ctx = config.get("configurable", {})
+    return await generate_image_with_provider(
+        canvas_id=ctx.get("canvas_id", ""),
+        session_id=ctx.get("session_id", ""),
+        provider="minimax",
+        model=model,
+        prompt=prompt,
+        aspect_ratio=aspect_ratio,
+        input_images=input_images,
+    )
+
+
+__all__ = ["generate_image_by_minimax"]

--- a/server/tools/image_providers/minimax_provider.py
+++ b/server/tools/image_providers/minimax_provider.py
@@ -1,0 +1,90 @@
+import os
+from typing import Any, Optional
+
+from services.config_service import FILES_DIR, config_service
+from utils.http_client import HttpClient
+
+from ..utils.image_utils import generate_image_id, get_image_info_and_save
+from .image_base_provider import ImageProviderBase
+
+
+class MiniMaxImageProvider(ImageProviderBase):
+    """MiniMax image generation provider implementation."""
+
+    async def generate(
+        self,
+        prompt: str,
+        model: str,
+        aspect_ratio: str = "1:1",
+        input_images: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> tuple[str, int, int, str]:
+        config = config_service.app_config.get("minimax", {})
+        api_key = str(config.get("api_key", ""))
+        api_url = str(
+            config.get("url", "https://api.minimax.io/v1/image_generation")
+        )
+
+        if not api_key:
+            raise ValueError("MiniMax API key is not configured")
+        if not api_url:
+            raise ValueError("MiniMax API URL is not configured")
+
+        payload: dict[str, Any] = {
+            "model": model.replace("minimax/", ""),
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "response_format": kwargs.get("response_format", "url"),
+            "n": kwargs.get("num_images", 1),
+            "prompt_optimizer": kwargs.get("prompt_optimizer", False),
+        }
+
+        if input_images:
+            payload["subject_reference"] = [
+                {"type": "character", "image_file": image}
+                for image in input_images
+            ]
+
+        for field in ("width", "height", "seed"):
+            if field in kwargs and kwargs[field] is not None:
+                payload[field] = kwargs[field]
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with HttpClient.create_aiohttp() as session:
+            async with session.post(api_url, json=payload, headers=headers) as response:
+                response_json = await response.json()
+                response_status = response.status
+
+        base_status = response_json.get("base_resp", {}).get("status_code")
+        if response_status != 200 or base_status not in (None, 0):
+            raise RuntimeError(f"MiniMax image generation failed: {response_json}")
+
+        data = response_json.get("data", {})
+        response_format = payload["response_format"]
+        if response_format == "base64":
+            images = data.get("image_base64", [])
+            is_b64 = True
+        else:
+            images = data.get("image_urls", [])
+            is_b64 = False
+
+        if not images:
+            raise RuntimeError("MiniMax image generation returned no images")
+
+        image_id = generate_image_id()
+        mime_type, width, height, extension = await get_image_info_and_save(
+            images[0],
+            os.path.join(FILES_DIR, image_id),
+            is_b64=is_b64,
+        )
+        if mime_type is None:
+            raise RuntimeError("Failed to determine generated image MIME type")
+
+        return mime_type, width, height, f"{image_id}.{extension}"
+
+
+__all__ = ["MiniMaxImageProvider"]

--- a/server/tools/utils/image_generation_core.py
+++ b/server/tools/utils/image_generation_core.py
@@ -10,6 +10,7 @@ from ..image_providers.image_base_provider import ImageProviderBase
 
 # 导入所有提供商以确保自动注册 (不要删除这些导入)
 from ..image_providers.jaaz_provider import JaazImageProvider
+from ..image_providers.minimax_provider import MiniMaxImageProvider
 from ..image_providers.openai_provider import OpenAIImageProvider
 from ..image_providers.replicate_provider import ReplicateImageProvider
 from ..image_providers.volces_provider import VolcesProvider
@@ -23,6 +24,7 @@ import time
 
 IMAGE_PROVIDERS: dict[str, ImageProviderBase] = {
     "jaaz": JaazImageProvider(),
+    "minimax": MiniMaxImageProvider(),
     "openai": OpenAIImageProvider(),
     "replicate": ReplicateImageProvider(),
     "volces": VolcesProvider(),


### PR DESCRIPTION
Reason: Complete MiniMax image-to-image generation by mapping reference images to subject_reference.

This registers MiniMax image models and exposes a selectable image tool. Reference images are sent as character subject references, and both URL and base64 image responses are saved through the existing image pipeline. Global and China endpoint URLs remain configurable.

Checks:
- `python3 -m compileall -q server/tools/image_providers/minimax_provider.py server/tools/generate_image_by_minimax.py server/tools/utils/image_generation_core.py server/services/config_service.py server/services/tool_service.py`
- `ruff check server/tools/image_providers/minimax_provider.py server/tools/generate_image_by_minimax.py`
- `git diff --check`
